### PR TITLE
Adding an ellipsis button and action menu to Manage Uploads

### DIFF
--- a/resources/js/Components/Buttons/MoreButton.jsx
+++ b/resources/js/Components/Buttons/MoreButton.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function MoreButton({ onClick, ...styles }) {
+    return (
+      <button
+        onClick={onClick}
+        className="w-10 h-10 flex items-center justify-center"
+        style={{...styles}}
+        aria-label="More options"
+        aria-haspopup="true"
+      >
+        <div className="flex space-x-1">
+          <div className="w-1 h-1 bg-[#1F1F1F] rounded-full"></div>
+          <div className="w-1 h-1 bg-[#1F1F1F] rounded-full"></div>
+          <div className="w-1 h-1 bg-[#1F1F1F] rounded-full"></div>
+        </div>
+      </button>
+    );
+  }
+  

--- a/resources/js/Components/OverflowMenu.jsx
+++ b/resources/js/Components/OverflowMenu.jsx
@@ -1,0 +1,105 @@
+import React, { useState, useRef, useEffect } from 'react';
+import MoreButton from '@/Components/Buttons/MoreButton';
+import PropTypes from 'prop-types';
+
+function OverflowMenu({ items }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const menuRef = useRef(null);
+
+    const buttonStyle = {
+        borderRadius: '8px',
+        border: isOpen ? '1px solid #F79222' : 'none',
+    }
+
+    const menuStyle = {
+        display: 'inline-flex',
+        padding: '10px 0px',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        borderRadius: '6px',
+        background: 'white',
+        boxShadow: '0px 1px 3px 0px rgba(166, 175, 195, 0.40)',
+    };
+
+    const itemStyle = {
+        display: 'flex',
+        width: '210px',
+        padding: '8px 20px',
+        alignItems: 'center',
+        gap: '10px',
+        color: '#374151',
+        fontSize: '16px',
+        fontWeight: '400',
+        lineHeight: '26px',
+    };
+
+    const handleToggle = (event) => {
+        setIsOpen(!isOpen);
+    };
+
+    const handleClickOutside = (event) => {
+        if (menuRef.current && !menuRef.current.contains(event.target)) {
+            setIsOpen(false);
+        }
+    };
+
+    useEffect(() => {
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        } else {
+            document.removeEventListener('mousedown', handleClickOutside);
+        }
+
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [isOpen]);
+
+    return (
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+            <MoreButton styles={buttonStyle} onClick={handleToggle}></MoreButton>
+            {isOpen && (
+                <div
+                    ref={menuRef}
+                    style={{
+                        position: 'absolute',
+                        top: '100%',
+                        right: 0,
+                        zIndex: 1,
+                        ...menuStyle,
+                    }}
+                >
+                    {items.map((item, index) => (
+                        <div
+                            key={index}
+                            style={{
+                                padding: '8px 16px',
+                                cursor: 'pointer',
+                                transition: 'background-color 0.3s ease, color 0.3s ease',
+                                ':hover': { backgroundColor: 'rgba(247, 146, 34, 0.05)', color: '#F79222' },
+                                ...itemStyle
+                            }}
+                            onClick={() => {
+                                item.onClick();
+                                setIsOpen(false);
+                            }}
+                        >
+                            {item.label}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}
+
+OverflowMenu.propTypes = {
+    items: PropTypes.arrayOf(
+        PropTypes.shape({
+            label: PropTypes.string.isRequired,
+            onClick: PropTypes.func.isRequired,
+        })
+    ).isRequired,
+};
+
+export default OverflowMenu;

--- a/resources/js/Pages/ManageUploads.jsx
+++ b/resources/js/Pages/ManageUploads.jsx
@@ -2,6 +2,7 @@ import AppLayout from '@/Layouts/AppLayout';
 import HeaderLabel from '@/Components/HeaderLabel';
 import { PlusCircleIcon } from '@heroicons/react/24/outline';
 import SortIcon from '@/Components/Icons/SortIcon';
+import OverflowMenu from '@/Components/OverflowMenu';
 import React, { useState, useEffect } from 'react';
 
 export default function ManageUploads() {
@@ -25,20 +26,26 @@ export default function ManageUploads() {
   };
 
   const mockUpload2 = {
-    batch_id: 'Id1',
+    batch_id: 'Id2',
     inst_id: '12345',
     file_names_to_ids: {
       'Very very long file name FileX.txt': '123',
       'Long file name FileY.txt': '124',
     },
-    name: 'Batch1',
-    created_by: 'Jane Doe',
+    name: 'Batch2',
+    created_by: 'John Doe',
     completed: true,
     deleted: false,
     updated_at: '01/02/2024 09:30:20',
     created_at: '01/02/2024 09:30:20',
-    updated_by: 'Jane Doe',
+    updated_by: 'John Doe',
   };
+
+  const actions = [
+    { label: 'Change batch name', onClick: () => console.log('Change batch name clicked') },
+    { label: 'Add files to batch', onClick: () => console.log('Add files to batch clicked') },
+    { label: 'Delete batch', onClick: () => console.log('Delete batch clicked') },
+  ];
 
   useEffect(() => {
     // To Do: Please replace by call to the backend API but keep the mock around for easy frontend testing.
@@ -77,7 +84,7 @@ export default function ManageUploads() {
   };
 
   const sortData = (column) => {
-    let sortedData = [...data]; 
+    let sortedData = [...data];
 
     if (sortColumn === column && sortDirection === 'asc') {
       setSortDirection('desc');
@@ -145,6 +152,9 @@ export default function ManageUploads() {
                 <th className='p-4 px-6'><button onClick={() => handleSort('date_modified')}>
                   <span className='inline-flex align-middle pr-2'>DATE MODIFIED</span><SortIcon />
                 </button></th>
+                <th className='p-4 px-6'>
+                  <span className='inline-flex align-middle pr-2'>ACTIONS</span>
+                </th>
               </tr>
             </thead>
 
@@ -172,6 +182,9 @@ export default function ManageUploads() {
                     </td>
                     <td className="p-4 px-6 font-medium">
                       {upload.updated_at}
+                    </td>
+                    <td className="p-4 px-6 font-medium">
+                      <OverflowMenu items={actions} />
                     </td>
                   </tr>
                 ),


### PR DESCRIPTION
Adding the Actions menu to Manage Uploads
<img width="1420" alt="Screenshot 2025-03-26 at 11 50 13 AM" src="https://github.com/user-attachments/assets/30266709-03be-4e43-a587-8e98b6cef3df" />

The action item onclick handlers haven't been wired up yet. The hover effect on the action items is also not working as yet.