### PR TITLE
fix: do not require verified email addresses

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -50,14 +50,12 @@ class Kernel extends HttpKernel
         'auth.app' => [
             \App\Http\Middleware\Authenticate::class,
             \App\Http\Middleware\EnsureTermsAccepted::class,
-            \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         ],
 
         'auth.app.invite' => [
             \App\Http\Middleware\Authenticate::class,
             \App\Http\Middleware\CheckInviteValidated::class,
             \App\Http\Middleware\EnsureTermsAccepted::class,
-            \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
         ],
     ];
 


### PR DESCRIPTION
## Changes
Remove EnsureEmailIsVerified from middleware groups

## Context
After a Laravel refactor EnsureEmailIsVerified was added to some middleware groups with the assumption that email addresses were being verified. I could not find any verified email addresses in the dev or staging user tables.

## Questions
Should we define the email verification process and ensure alignment?