### PR TITLE
feat: Edvise and Legacy institution type options (re-added)

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -135,6 +135,18 @@ class ApiController extends Controller
         if ($request->input('pdp_id') != null) {
             $post_request_body['pdp_id'] = $request->input('pdp_id');
         }
+        if ($request->input('is_edvise') != null) {
+            $post_request_body['is_edvise'] = $request->input('is_edvise');
+        }
+        if ($request->input('edvise_id') != null && $request->input('edvise_id') != '') {
+            $post_request_body['edvise_id'] = $request->input('edvise_id');
+        }
+        if ($request->input('is_legacy') != null) {
+            $post_request_body['is_legacy'] = $request->input('is_legacy');
+        }
+        if ($request->input('legacy_id') != null && $request->input('legacy_id') != '') {
+            $post_request_body['legacy_id'] = $request->input('legacy_id');
+        }
         if ($request->input('retention_days') != null && $request->input('retention_days') != '') {
             $post_request_body['retention_days'] = $request->input('retention_days');
         }
@@ -234,8 +246,21 @@ class ApiController extends Controller
             }
             $req_body['is_pdp'] = $request->input('is_pdp');
         }
-        if ($request->input('pdp_id') != null) {
-            $req_body['pdp_id'] = $request->input('pdp_id');
+        // Forward school-type IDs when present (including null) so API can clear when switching type
+        if ($request->has('pdp_id')) {
+            $req_body['pdp_id'] = $request->input('pdp_id') ?: null;
+        }
+        if ($request->input('is_edvise') != null) {
+            $req_body['is_edvise'] = $request->input('is_edvise');
+        }
+        if ($request->has('edvise_id')) {
+            $req_body['edvise_id'] = $request->input('edvise_id') ?: null;
+        }
+        if ($request->input('is_legacy') != null) {
+            $req_body['is_legacy'] = $request->input('is_legacy');
+        }
+        if ($request->has('legacy_id')) {
+            $req_body['legacy_id'] = $request->input('legacy_id') ?: null;
         }
         if ($request->input('retention_days') != null && $request->input('retention_days') != '') {
             $req_body['retention_days'] = $request->input('retention_days');

--- a/resources/js/Pages/CreateInst.jsx
+++ b/resources/js/Pages/CreateInst.jsx
@@ -13,6 +13,8 @@ export default function CreateInst() {
   const schemas = [
     { name: 'Custom', selected: false },
     { name: 'PDP', selected: false },
+    { name: 'Edvise', selected: false },
+    { name: 'Legacy', selected: false },
   ];
 
   const [addUserCounter, setAddUserCounter] = useState(0);
@@ -83,16 +85,26 @@ export default function CreateInst() {
       return;
     }
     // Enforce the selection of at least one schema type.
-    // NOTE: As schemas get added here, you'll need to expand this if check to include those schemas as well.
+    const edvise = event.target.elements.Edvise?.checked ?? false;
+    const legacy = event.target.elements.Legacy?.checked ?? false;
     if (
       !event.target.elements.Custom.checked &&
-      !event.target.elements.PDP.checked
+      !event.target.elements.PDP.checked &&
+      !edvise &&
+      !legacy
     ) {
       document.getElementById('result_area').innerHTML =
         'Error: Schema type must contain at least one selection.';
       return;
     }
-    // We currently only have custom for potential other schemas. NOte that the shema passed to the API call must match the corresponding backend schema enum value.
+    // At most one of PDP, Edvise, or Legacy (API allows only one school type).
+    const schoolTypeCount = [event.target.elements.PDP.checked, edvise, legacy].filter(Boolean).length;
+    if (schoolTypeCount > 1) {
+      document.getElementById('result_area').innerHTML =
+        'Error: Select at most one of PDP, Edvise, or Legacy.';
+      return;
+    }
+    // We currently only have custom for potential other schemas. Note that the schema passed to the API call must match the corresponding backend schema enum value.
     let other_schemas = event.target.elements.Custom.checked
       ? ['UNKNOWN']
       : null;
@@ -115,18 +127,21 @@ export default function CreateInst() {
         constructedEmailDict[value] = accessDict[key];
       }
     }
+    const payload = {
+      name: event.target.elements.inst_name.value,
+      state: event.target.elements.state.value,
+      allowed_schemas: other_schemas,
+      allowed_emails:
+        constructedEmailDict.length == 0 ? null : constructedEmailDict,
+      is_pdp: pdp,
+      pdp_id: event.target.elements.pdp_id?.value || null,
+    };
+    if (edvise) payload.is_edvise = true;
+    if (legacy) payload.is_legacy = true;
     return axios({
       method: 'post',
       url: '/create-inst-api',
-      data: {
-        name: event.target.elements.inst_name.value,
-        state: event.target.elements.state.value,
-        allowed_schemas: other_schemas,
-        allowed_emails:
-          constructedEmailDict.length == 0 ? null : constructedEmailDict,
-        is_pdp: pdp,
-        pdp_id: event.target.elements.pdp_id.value,
-      },
+      data: payload,
     })
       .then(res => {
         document.getElementById('result_area').innerHTML =

--- a/resources/js/Pages/EditInst.jsx
+++ b/resources/js/Pages/EditInst.jsx
@@ -19,6 +19,8 @@ export default function EditInst() {
   const [schemas] = useState([
     { name: 'Custom', selected: false },
     { name: 'PDP', selected: false },
+    { name: 'Edvise', selected: false },
+    { name: 'Legacy', selected: false },
   ]);
 
   const removeItem = (itemId) => {
@@ -120,17 +122,30 @@ export default function EditInst() {
   const handleSubmit = async (event) => {
     event.preventDefault();
     const formData = new FormData(event.target);
-    
+    const pdp = formData.get('PDP') === 'on';
+    const edvise = formData.get('Edvise') === 'on';
+    const legacy = formData.get('Legacy') === 'on';
+    const schoolTypeCount = [pdp, edvise, legacy].filter(Boolean).length;
+    if (schoolTypeCount > 1) {
+      setError('Select at most one of PDP, Edvise, or Legacy.');
+      return;
+    }
+    // API only updates fields that are sent; to clear a school type we must send null explicitly.
+    // Omit edvise_id/legacy_id when that type is selected (no input to set; preserve existing).
+    const payload = {
+      name: formData.get('inst_name'),
+      state: formData.get('state'),
+      allowed_schemas: formData.get('Custom') ? ['UNKNOWN'] : null,
+      allowed_emails: constructEmailDict(formData),
+      is_pdp: pdp,
+      pdp_id: pdp ? (formData.get('pdp_id') || null) : null,
+      edvise_id: edvise ? undefined : null, // omit when Edvise so API keeps existing; null clears
+      legacy_id: legacy ? undefined : null,  // omit when Legacy so API keeps existing; null clears
+    };
+    if (edvise) payload.is_edvise = true;
+    if (legacy) payload.is_legacy = true;
     try {
-      const response = await axios.post('/edit-inst-api', {
-        name: formData.get('inst_name'),
-        state: formData.get('state'),
-        allowed_schemas: formData.get('Custom') ? ['UNKNOWN'] : null,
-        allowed_emails: constructEmailDict(formData),
-        is_pdp: formData.get('PDP') === 'on',
-        pdp_id: formData.get('pdp_id'),
-      });
-
+      await axios.post('/edit-inst-api', payload);
       setError(null);
     } catch (err) {
       setError(err.response?.data?.error || err.message);
@@ -268,7 +283,6 @@ export default function EditInst() {
                 </p>
               </div>
             </div>
-            <div className="flex flex-row w-full gap-x-6"></div>
             <div id="mult_users" className="flex flex-col">
               {renderFullEmailList()}
             </div>


### PR DESCRIPTION
# feat(ui): Edvise and Legacy institution type options

## Summary

Adds **Edvise** and **Legacy** as institution schema/school-type options on Create and Edit Institution, and ensures the Edit flow sends explicit nulls so the API can clear school type when switching (e.g. Legacy → PDP).

## Changes

### Create Institution (`CreateInst.jsx`)

- Added **Edvise** and **Legacy** to the "Schemas accepted by this institution" checkboxes (alongside Custom and PDP).
- Validation:
  - At least one schema type must be selected.
  - At most one of **PDP**, **Edvise**, or **Legacy** (aligned with API’s single school-type rule).
- Payload: sends `is_edvise` / `is_legacy` when selected; `edvise_id` and `legacy_id` are omitted so the API auto-assigns (e.g. `edvise_1`, `legacy_1`).

### Edit Institution (`EditInst.jsx`)

- Same Edvise and Legacy options and "at most one of PDP/Edvise/Legacy" validation.
- **PATCH behavior:** Always sends `pdp_id`, and when not Edvise/Legacy sends `edvise_id: null` / `legacy_id: null` so the API can clear those types. When Edvise or Legacy is selected, omits that ID so the API preserves the existing value (no manual ID input on Edit).

### API proxy (`ApiController.php`)

- **Create (POST):** Forwards `is_edvise`, `edvise_id`, `is_legacy`, `legacy_id` to the backend when present.
- **Edit (PATCH):** Uses `$request->has('pdp_id'|'edvise_id'|'legacy_id')` and forwards the value (including `null`) so the backend can clear school type when the UI switches selection.

## Dependencies

- **Depends on API PR:** [feat: legacy school type with any-format uploads, PII check, and Edvise Schema (ES) naming](https://github.com/datakind/edvise-api/pull/208) (branch: `feat/legacy-school-classifier` → `develop`).
  - That PR adds `legacy_id` and Edvise/Legacy support to the institutions API, auto-assigns `edvise_id`/`legacy_id` on create, and implements the legacy validation path. This UI branch relies on:
    - Institution create/update with `is_edvise` / `edvise_id` and `is_legacy` / `legacy_id`.
    - PATCH that updates only sent fields (so sending `pdp_id` + `edvise_id: null` + `legacy_id: null` clears Edvise/Legacy).

## Testing plan

- **Create:** Create institution with only Edvise selected → verify API returns an institution with `edvise_id` set (e.g. `edvise_1`). Same for Legacy.
- **Create:** Try selecting both PDP and Legacy → UI should show "Select at most one of PDP, Edvise, or Legacy."
- **Edit:** Change an institution from Legacy to PDP (set PDP, clear others) → verify PATCH succeeds and institution has only `pdp_id` set.

## Known issues (pre-existing)

- **EditInst** calls `constructEmailDict(formData)` but this function is not defined anywhere; submitting the Edit form will throw `ReferenceError`. This predates this branch. Consider implementing or replacing before relying on Edit Institution in production.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213450406365299