### PR TITLE
hotfix: Set Institution flow and database config

### DIFF
--- a/app/Http/Middleware/RequireInstitution.php
+++ b/app/Http/Middleware/RequireInstitution.php
@@ -14,6 +14,17 @@ class RequireInstitution
         'createInstApi', 'addDatakinderApi', 'viewAllInstitutions', 'EditInstApi',
     ];
 
+    /** Route names (and patterns) that do not require an institution. */
+    private const SKIP_ROUTES = [
+        'set-inst',
+        'logout',
+        'profile.*',
+        'add-dk',
+        'create-inst',
+        'admin.invites',
+        'admin.invites.*',
+    ];
+
     public function handle(Request $request, Closure $next): Response
     {
         if (! $request->user()) {
@@ -24,7 +35,12 @@ class RequireInstitution
             return $next($request);
         }
 
-        if ($request->routeIs('set-inst') || $request->routeIs('logout') || $request->routeIs('profile.*') || $request->is('set-inst-api*')) {
+        foreach (self::SKIP_ROUTES as $pattern) {
+            if ($request->routeIs($pattern)) {
+                return $next($request);
+            }
+        }
+        if ($request->is('set-inst-api*')) {
             return $next($request);
         }
 

--- a/config/database.php
+++ b/config/database.php
@@ -60,10 +60,10 @@ return [
             'engine' => null,
             'sslmode' => 'require',
             'options' => [
-                \Pdo\Mysql::ATTR_SSL_CA => env('SSL_CA_PATH'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
-                \Pdo\Mysql::ATTR_SSL_KEY => env('SSL_KEY_PATH'),
-                \Pdo\Mysql::ATTR_SSL_CERT => env('SSL_CERT_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
+                \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                \PDO::MYSQL_ATTR_SSL_KEY => env('SSL_KEY_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CERT => env('SSL_CERT_PATH'),
             ],
         ],
 
@@ -83,7 +83,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/socialite/config/database.php
+++ b/socialite/config/database.php
@@ -58,10 +58,10 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                Pdo\Mysql::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
-                Pdo\Mysql::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
-                Pdo\Mysql::MYSQL_ATTR_SSL_KEY => env('SSL_KEY_PATH'),
-                Pdo\Mysql::MYSQL_ATTR_SSL_CERT => env('SSL_CERT_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
+                \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                \PDO::MYSQL_ATTR_SSL_KEY => env('SSL_KEY_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CERT => env('SSL_CERT_PATH'),
             ]) : [],
         ],
 
@@ -81,7 +81,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                Pdo\Mysql::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
             ]) : [],
         ],
 


### PR DESCRIPTION
https://app.asana.com/1/6325821815997/project/1209940426025913/task/1213600568715389

## Hotfix: 

### Summary
- Fixes two issues: (1) Datakinders can complete Add Datakinders, Create institution, and Manage invites without being blocked by the institution requirement
- database config uses the correct PDO constants for MySQL SSL.

### What changed

**1. RequireInstitution middleware**
- Introduced a **`SKIP_ROUTES`** constant so all “skip set institution” routes live in one place.
- Exempt routes: `set-inst`, `logout`, `profile.*`, `set-inst-api*`, plus **Add Datakinders** (`add-dk`), **Create institution** (`create-inst`), and **Manage invites** (`admin.invites`, `admin.invites.*`).
- Admins can add Datakinders, create institutions, and manage invites without having an institution set.

**2. Database config**
Replaced the newer MySQL SSL option format (unsupported in our production PHP version) with PDO constants (\PDO::MYSQL_ATTR_SSL_CA, etc.) in config/database.php so SSL is set in a way that works and stays readable.

### Why (hotfix)
- Datakinders were blocked from completing the Add Datakinders, Create institution, and Manage invites admin actions when no institution was set.
- Using old PDO constants until we upgrade php version.
