### PR TITLE
hotfix: Set Institution flow + PDO constants (for production)

### DIFF
--- a/app/Http/Middleware/RequireInstitution.php
+++ b/app/Http/Middleware/RequireInstitution.php
@@ -14,6 +14,17 @@ class RequireInstitution
         'createInstApi', 'addDatakinderApi', 'viewAllInstitutions', 'EditInstApi',
     ];
 
+    /** Route names (and patterns) that do not require an institution. */
+    private const SKIP_ROUTES = [
+        'set-inst',
+        'logout',
+        'profile.*',
+        'add-dk',
+        'create-inst',
+        'admin.invites',
+        'admin.invites.*',
+    ];
+
     public function handle(Request $request, Closure $next): Response
     {
         if (! $request->user()) {
@@ -24,7 +35,12 @@ class RequireInstitution
             return $next($request);
         }
 
-        if ($request->routeIs('set-inst') || $request->routeIs('logout') || $request->routeIs('profile.*') || $request->is('set-inst-api*')) {
+        foreach (self::SKIP_ROUTES as $pattern) {
+            if ($request->routeIs($pattern)) {
+                return $next($request);
+            }
+        }
+        if ($request->is('set-inst-api*')) {
             return $next($request);
         }
 

--- a/config/database.php
+++ b/config/database.php
@@ -60,10 +60,10 @@ return [
             'engine' => null,
             'sslmode' => 'require',
             'options' => [
-                \Pdo\Mysql::ATTR_SSL_CA => env('SSL_CA_PATH'),
-                \Pdo\Mysql::ATTR_SSL_VERIFY_SERVER_CERT => false,
-                \Pdo\Mysql::ATTR_SSL_KEY => env('SSL_KEY_PATH'),
-                \Pdo\Mysql::ATTR_SSL_CERT => env('SSL_CERT_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
+                \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                \PDO::MYSQL_ATTR_SSL_KEY => env('SSL_KEY_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CERT => env('SSL_CERT_PATH'),
             ],
         ],
 
@@ -83,7 +83,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                \Pdo\Mysql::ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/socialite/config/database.php
+++ b/socialite/config/database.php
@@ -58,10 +58,10 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                Pdo\Mysql::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
-                Pdo\Mysql::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
-                Pdo\Mysql::MYSQL_ATTR_SSL_KEY => env('SSL_KEY_PATH'),
-                Pdo\Mysql::MYSQL_ATTR_SSL_CERT => env('SSL_CERT_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
+                \PDO::MYSQL_ATTR_SSL_VERIFY_SERVER_CERT => false,
+                \PDO::MYSQL_ATTR_SSL_KEY => env('SSL_KEY_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CERT => env('SSL_CERT_PATH'),
             ]) : [],
         ],
 
@@ -81,7 +81,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                Pdo\Mysql::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
+                \PDO::MYSQL_ATTR_SSL_CA => env('SSL_CA_PATH'),
             ]) : [],
         ],
 


### PR DESCRIPTION
Same changes as [245](https://github.com/datakind/edvise-ui/pull/245) — that PR was merged into `develop` by mistake. This PR targets `main` so the fix can be deployed to production.

### Summary
- **RequireInstitution:** `SKIP_ROUTES` constant; exempt set-inst, logout, profile, and admin routes (Add Datakinders, Create institution, Manage invites) so Datakinders aren’t blocked.
- **Database config:** Use PDO constants for MySQL SSL so config works on our current production PHP version.
