### PR TITLE
fix: Set inst_id for non-Datakinders

### DIFF
--- a/app/Http/Middleware/RequireInstitution.php
+++ b/app/Http/Middleware/RequireInstitution.php
@@ -32,6 +32,11 @@ class RequireInstitution
         }
 
         if ($request->user()->access_type !== 'DATAKINDER') {
+            [$inst, ] = InstitutionHelper::GetInstitution($request);
+            if ($inst !== null && $inst !== '') {
+                $request->attributes->set('inst_id', $inst);
+            }
+
             return $next($request);
         }
 


### PR DESCRIPTION
## Asana Task
https://app.asana.com/0/0/task/1213642336231612

## Changes
Set the inst_id for non-Datakinders

## Context
End users were reporting issues viewing their model results and EDA. The issue was caused by the absence of the inst_id in various API calls.

## Recomendation
Ensure that the inst_id is handled in the same way for Datakinders and non-Datakinders alike

## Questions
Should we have a way to access the app as a regular user? How can DataKinders perform QA on the app from the view of the end users?

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213642336231612