### PR TITLE
fix: Set inst_id for non-Datakinders

### DIFF
--- a/app/Http/Middleware/RequireInstitution.php
+++ b/app/Http/Middleware/RequireInstitution.php
@@ -32,6 +32,11 @@ class RequireInstitution
         }
 
         if ($request->user()->access_type !== 'DATAKINDER') {
+            [$inst, ] = InstitutionHelper::GetInstitution($request);
+            if ($inst !== null && $inst !== '') {
+                $request->attributes->set('inst_id', $inst);
+            }
+
             return $next($request);
         }
 


### PR DESCRIPTION
See https://github.com/datakind/edvise-ui/pull/249

This hotfix was accidentally merged into develop instead of main