### PR TITLE
feat: change logo link to app-home

### DIFF
--- a/resources/js/Layouts/AppLayout.jsx
+++ b/resources/js/Layouts/AppLayout.jsx
@@ -412,7 +412,7 @@ export default function AppLayout({ title, renderHeader, children }) {
                 className="flex h-16 shrink-0 flex-col items-center pt-12"
                 key="logo"
               >
-                <a href={route('home')}>
+                <a href={route('app-home')}>
                   <img
                     className="w-full pb-12"
                     src="https://storage.googleapis.com/staging-sst-01-staging-static/edvise-logo.svg"


### PR DESCRIPTION
https://app.asana.com/0/0/task/1213601327806206

## Changes
Change the link around the Logo to app-home

## Context
The link around the logo was not the same as the home button link. Now both link to the same route.