### PR TITLE
fix(ui): wait for long validate-upload and surface real proxy errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,8 +66,12 @@ VITE_GTM_ID=
 
 # The following values need to be coordinated with the backend binary.
 BACKEND_URL=
-# Seconds for Laravel HTTP client when proxying to BACKEND_URL (e.g. large CSV validate-upload).
-BACKEND_HTTP_TIMEOUT_SECONDS=300
+# Laravel HTTP client timeouts when proxying to BACKEND_URL (seconds).
+BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS=30
+# Only /input/validate-upload/* (large CSV validation); other paths use DEFAULT above.
+BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS=300
+# Optional legacy alias for VALIDATE timeout (used if VALIDATE is unset).
+# BACKEND_HTTP_TIMEOUT_SECONDS=300
 BACKEND_TIMEOUT_LESS_FIVE=115
 
 BACKEND_API_KEY=""

--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,8 @@ VITE_GTM_ID=
 
 # The following values need to be coordinated with the backend binary.
 BACKEND_URL=
+# Seconds for Laravel HTTP client when proxying to BACKEND_URL (e.g. large CSV validate-upload).
+BACKEND_HTTP_TIMEOUT_SECONDS=300
 BACKEND_TIMEOUT_LESS_FIVE=115
 
 BACKEND_API_KEY=""

--- a/.env.example
+++ b/.env.example
@@ -70,8 +70,6 @@ BACKEND_URL=
 BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS=30
 # Only /input/validate-upload/* (large CSV validation); other paths use DEFAULT above.
 BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS=300
-# Optional legacy alias for VALIDATE timeout (used if VALIDATE is unset).
-# BACKEND_HTTP_TIMEOUT_SECONDS=300
 BACKEND_TIMEOUT_LESS_FIVE=115
 
 BACKEND_API_KEY=""

--- a/.github/workflows/precommit-tests.yml
+++ b/.github/workflows/precommit-tests.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Install more dependencies
         run: npm install
       - name: Build vite assets
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: npm run build
       - name: Run tests
         run: php artisan test

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -191,23 +191,30 @@ class ApiController extends Controller
         $url = env('BACKEND_URL').'/institutions/'.$request->attributes->get('inst_id').$url_piece;
         \Log::info('constructInstRequest - Full URL being called: '.$url);
         \Log::info('constructInstRequest - Query parameters: '.json_encode($request->query()));
+        // Large CSV validate-upload can exceed Laravel's default ~30s HTTP client timeout while
+        // Cloud Run may allow up to e.g. 300s; keep proxy wait aligned with the API.
+        $backendTimeoutSeconds = (int) env('BACKEND_HTTP_TIMEOUT_SECONDS', 300);
+        if ($backendTimeoutSeconds < 1) {
+            $backendTimeoutSeconds = 300;
+        }
+        $http = Http::withHeaders($headers)->timeout($backendTimeoutSeconds);
         $resp = null;
         if ($method == 'GET') {
-            $resp = Http::withHeaders($headers)->get($url, $request->query());
+            $resp = $http->get($url, $request->query());
         } elseif ($method == 'POST') {
             if ($req_body == null) {
-                $resp = Http::withHeaders($headers)->post($url);
+                $resp = $http->post($url);
             } else {
-                $resp = Http::withHeaders($headers)->post($url, $req_body);
+                $resp = $http->post($url, $req_body);
             }
         } elseif ($method == 'PATCH') {
             if ($req_body == null) {
-                $resp = Http::withHeaders($headers)->patch($url);
+                $resp = $http->patch($url);
             } else {
-                $resp = Http::withHeaders($headers)->patch($url, $req_body);
+                $resp = $http->patch($url, $req_body);
             }
         } elseif ($method == 'DELETE') {
-            $resp = Http::withHeaders($headers)->delete($url);
+            $resp = $http->delete($url);
         } else {
             return response()->json(['error' => 'Unrecognized HTTP method'], 500);
         }

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -194,12 +194,7 @@ class ApiController extends Controller
         // Only validate-upload needs a long wait (large CSV); other institution calls keep a short timeout.
         $isValidateUpload = str_starts_with($url_piece, '/input/validate-upload');
         if ($isValidateUpload) {
-            $validateTimeoutRaw = env('BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS');
-            if ($validateTimeoutRaw === null || $validateTimeoutRaw === '') {
-                // Deprecated name; kept for env files deployed from earlier UI releases.
-                $validateTimeoutRaw = env('BACKEND_HTTP_TIMEOUT_SECONDS', 300);
-            }
-            $backendTimeoutSeconds = (int) $validateTimeoutRaw;
+            $backendTimeoutSeconds = (int) env('BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS', 300);
             if ($backendTimeoutSeconds < 1) {
                 $backendTimeoutSeconds = 300;
             }

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -191,11 +191,23 @@ class ApiController extends Controller
         $url = env('BACKEND_URL').'/institutions/'.$request->attributes->get('inst_id').$url_piece;
         \Log::info('constructInstRequest - Full URL being called: '.$url);
         \Log::info('constructInstRequest - Query parameters: '.json_encode($request->query()));
-        // Large CSV validate-upload can exceed Laravel's default ~30s HTTP client timeout while
-        // Cloud Run may allow up to e.g. 300s; keep proxy wait aligned with the API.
-        $backendTimeoutSeconds = (int) env('BACKEND_HTTP_TIMEOUT_SECONDS', 300);
-        if ($backendTimeoutSeconds < 1) {
-            $backendTimeoutSeconds = 300;
+        // Only validate-upload needs a long wait (large CSV); other institution calls keep a short timeout.
+        $isValidateUpload = str_starts_with($url_piece, '/input/validate-upload');
+        if ($isValidateUpload) {
+            $validateTimeoutRaw = env('BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS');
+            if ($validateTimeoutRaw === null || $validateTimeoutRaw === '') {
+                // Deprecated name; kept for env files deployed from earlier UI releases.
+                $validateTimeoutRaw = env('BACKEND_HTTP_TIMEOUT_SECONDS', 300);
+            }
+            $backendTimeoutSeconds = (int) $validateTimeoutRaw;
+            if ($backendTimeoutSeconds < 1) {
+                $backendTimeoutSeconds = 300;
+            }
+        } else {
+            $backendTimeoutSeconds = (int) env('BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS', 30);
+            if ($backendTimeoutSeconds < 1) {
+                $backendTimeoutSeconds = 30;
+            }
         }
         $http = Http::withHeaders($headers)->timeout($backendTimeoutSeconds);
         $resp = null;

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -16,6 +16,12 @@ class ApiController extends Controller
 {
     use UsesApi;
 
+    /** Fallback when BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS is unset or invalid (below 1 second). */
+    private const BACKEND_VALIDATE_TIMEOUT_FALLBACK_SECONDS = 300;
+
+    /** Fallback when BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS is unset or invalid (below 1 second). */
+    private const BACKEND_DEFAULT_TIMEOUT_FALLBACK_SECONDS = 30;
+
     // For printline debugging the following example added in the function will output to console in the 'php artisan serve' pane.
     // $out = new \Symfony\Component\Console\Output\ConsoleOutput();
     // $out->writeln("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1");
@@ -167,6 +173,29 @@ class ApiController extends Controller
         return ApiController::constructDatakinderRequest($request, '/institutions', 'GET', /* No POST body */ null);
     }
 
+    /**
+     * HTTP client timeout (seconds) when proxying institution requests to BACKEND_URL.
+     * Validate-upload needs a long wait for large CSV processing; other paths stay short.
+     */
+    private static function institutionBackendTimeoutSeconds(string $urlPiece): int
+    {
+        $isValidateUpload = str_starts_with($urlPiece, '/input/validate-upload');
+        if ($isValidateUpload) {
+            $seconds = (int) env(
+                'BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS',
+                self::BACKEND_VALIDATE_TIMEOUT_FALLBACK_SECONDS
+            );
+
+            return $seconds >= 1 ? $seconds : self::BACKEND_VALIDATE_TIMEOUT_FALLBACK_SECONDS;
+        }
+        $seconds = (int) env(
+            'BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS',
+            self::BACKEND_DEFAULT_TIMEOUT_FALLBACK_SECONDS
+        );
+
+        return $seconds >= 1 ? $seconds : self::BACKEND_DEFAULT_TIMEOUT_FALLBACK_SECONDS;
+    }
+
     // Constructs a query with the BACKEND_URL+/institutions/<inst> prefix.
     public function constructInstRequest(Request $request, string $url_piece, string $method, $req_body)
     {
@@ -191,20 +220,7 @@ class ApiController extends Controller
         $url = env('BACKEND_URL').'/institutions/'.$request->attributes->get('inst_id').$url_piece;
         \Log::info('constructInstRequest - Full URL being called: '.$url);
         \Log::info('constructInstRequest - Query parameters: '.json_encode($request->query()));
-        // Only validate-upload needs a long wait (large CSV); other institution calls keep a short timeout.
-        $isValidateUpload = str_starts_with($url_piece, '/input/validate-upload');
-        if ($isValidateUpload) {
-            $backendTimeoutSeconds = (int) env('BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS', 300);
-            if ($backendTimeoutSeconds < 1) {
-                $backendTimeoutSeconds = 300;
-            }
-        } else {
-            $backendTimeoutSeconds = (int) env('BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS', 30);
-            if ($backendTimeoutSeconds < 1) {
-                $backendTimeoutSeconds = 30;
-            }
-        }
-        $http = Http::withHeaders($headers)->timeout($backendTimeoutSeconds);
+        $http = Http::withHeaders($headers)->timeout(self::institutionBackendTimeoutSeconds($url_piece));
         $resp = null;
         if ($method == 'GET') {
             $resp = $http->get($url, $request->query());

--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -537,7 +537,7 @@ export default function FileUpload() {
         'Content-Type': 'text/csv',
       },
     };
-    // Align with Laravel proxy BACKEND_HTTP_TIMEOUT_SECONDS (large CSV validate can take minutes).
+    // Align with Laravel validate-upload proxy timeout (BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS, default 300s).
     const validateRequestMs = 300000;
     Promise.allSettled(
       files.map(file => {

--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -20,6 +20,35 @@ import HeaderLabel from '@/Components/HeaderLabel';
 import Spinner from '@/Components/Spinner';
 import { set } from 'lodash';
 
+/** Human-readable message from axios errors (Laravel `error`, FastAPI `detail`, etc.). */
+function axiosErrorMessage(e) {
+  if (!e.response) {
+    return e.message || 'Network error (no response)';
+  }
+  const d = e.response.data;
+  if (d == null) {
+    return `HTTP ${e.response.status}`;
+  }
+  if (typeof d === 'string') {
+    return d;
+  }
+  if (typeof d === 'object') {
+    if (d.error != null) {
+      return String(d.error);
+    }
+    if (d.detail != null) {
+      return typeof d.detail === 'object'
+        ? JSON.stringify(d.detail)
+        : String(d.detail);
+    }
+    if (d.message != null) {
+      return String(d.message);
+    }
+    return JSON.stringify(d);
+  }
+  return String(d);
+}
+
 export default function FileUpload() {
   // TODO: Change the state structure to handle multiple file status
   // TODO: Use buttons where static onclick changes are happenings and links otherwise.
@@ -508,6 +537,8 @@ export default function FileUpload() {
         'Content-Type': 'text/csv',
       },
     };
+    // Align with Laravel proxy BACKEND_HTTP_TIMEOUT_SECONDS (large CSV validate can take minutes).
+    const validateRequestMs = 300000;
     Promise.allSettled(
       files.map(file => {
         var filenameConstructed = Date.now() + '_' + file.name;
@@ -526,39 +557,28 @@ export default function FileUpload() {
               .put(res.data, file, config)
               .then(res1 => {
                 return axios
-                  .post('/file-validate-api/' + filenameConstructed)
+                  .post(
+                    '/file-validate-api/' + filenameConstructed,
+                    {},
+                    { timeout: validateRequestMs },
+                  )
                   .then(res2 => {
                     localValidationResults[filenameConstructed] = 'ok';
                     return;
                   })
                   .catch(e => {
-                    if (e.response) {
-                      localValidationResults[filenameConstructed] =
-                        '[Validation] ' + e.response.data.error;
-                    } else {
-                      localValidationResults[filenameConstructed] =
-                        '[Validation] ' + JSON.stringify(e);
-                    }
+                    localValidationResults[filenameConstructed] =
+                      '[Validation] ' + axiosErrorMessage(e);
                   });
               })
               .catch(e => {
-                if (e.response) {
-                  localValidationResults[filenameConstructed] =
-                    '[Upload] ' + e.response.data.error;
-                } else {
-                  localValidationResults[filenameConstructed] =
-                    '[Upload] ' + JSON.stringify(e);
-                }
+                localValidationResults[filenameConstructed] =
+                  '[Upload] ' + axiosErrorMessage(e);
               });
           })
           .catch(e => {
-            if (e.response) {
-              localValidationResults[filenameConstructed] =
-                '[Upload URL retrieval] ' + e.response.data.error;
-            } else {
-              localValidationResults[filenameConstructed] =
-                '[Upload URL retrieval] ' + JSON.stringify(e);
-            }
+            localValidationResults[filenameConstructed] =
+              '[Upload URL retrieval] ' + axiosErrorMessage(e);
           });
       }),
     ).then(() => {

--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -20,33 +20,39 @@ import HeaderLabel from '@/Components/HeaderLabel';
 import Spinner from '@/Components/Spinner';
 import { set } from 'lodash';
 
-/** Human-readable message from axios errors (Laravel `error`, FastAPI `detail`, etc.). */
-function axiosErrorMessage(e) {
-  if (!e.response) {
-    return e.message || 'Network error (no response)';
+/** Keep in sync with BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS (seconds) on the Laravel proxy. */
+const VALIDATE_UPLOAD_TIMEOUT_MS = 300_000;
+
+/**
+ * Build a human-readable message from an axios error (Laravel `error`, FastAPI `detail`, etc.).
+ * @param {unknown} error
+ */
+function formatAxiosErrorMessage(error) {
+  if (error == null || !error.response) {
+    return (error && error.message) || 'Network error (no response)';
   }
-  const d = e.response.data;
-  if (d == null) {
-    return `HTTP ${e.response.status}`;
+  const responseData = error.response.data;
+  if (responseData == null) {
+    return `HTTP ${error.response.status}`;
   }
-  if (typeof d === 'string') {
-    return d;
+  if (typeof responseData === 'string') {
+    return responseData;
   }
-  if (typeof d === 'object') {
-    if (d.error != null) {
-      return String(d.error);
+  if (typeof responseData === 'object') {
+    if (responseData.error != null) {
+      return String(responseData.error);
     }
-    if (d.detail != null) {
-      return typeof d.detail === 'object'
-        ? JSON.stringify(d.detail)
-        : String(d.detail);
+    if (responseData.detail != null) {
+      return typeof responseData.detail === 'object'
+        ? JSON.stringify(responseData.detail)
+        : String(responseData.detail);
     }
-    if (d.message != null) {
-      return String(d.message);
+    if (responseData.message != null) {
+      return String(responseData.message);
     }
-    return JSON.stringify(d);
+    return JSON.stringify(responseData);
   }
-  return String(d);
+  return String(responseData);
 }
 
 export default function FileUpload() {
@@ -537,8 +543,6 @@ export default function FileUpload() {
         'Content-Type': 'text/csv',
       },
     };
-    // Align with Laravel validate-upload proxy timeout (BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS, default 300s).
-    const validateRequestMs = 300000;
     Promise.allSettled(
       files.map(file => {
         var filenameConstructed = Date.now() + '_' + file.name;
@@ -560,7 +564,7 @@ export default function FileUpload() {
                   .post(
                     '/file-validate-api/' + filenameConstructed,
                     {},
-                    { timeout: validateRequestMs },
+                    { timeout: VALIDATE_UPLOAD_TIMEOUT_MS },
                   )
                   .then(res2 => {
                     localValidationResults[filenameConstructed] = 'ok';
@@ -568,17 +572,17 @@ export default function FileUpload() {
                   })
                   .catch(e => {
                     localValidationResults[filenameConstructed] =
-                      '[Validation] ' + axiosErrorMessage(e);
+                      '[Validation] ' + formatAxiosErrorMessage(e);
                   });
               })
               .catch(e => {
                 localValidationResults[filenameConstructed] =
-                  '[Upload] ' + axiosErrorMessage(e);
+                  '[Upload] ' + formatAxiosErrorMessage(e);
               });
           })
           .catch(e => {
             localValidationResults[filenameConstructed] =
-              '[Upload URL retrieval] ' + axiosErrorMessage(e);
+              '[Upload URL retrieval] ' + formatAxiosErrorMessage(e);
           });
       }),
     ).then(() => {


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes

- **`ApiController::constructInstRequest`**: Laravel’s HTTP client now uses an explicit **`timeout()`** when proxying to `BACKEND_URL`. **Only** requests whose path starts with **`/input/validate-upload`** use a long timeout from **`BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS`** (default **300**s, clamped if &lt; 1). All other institution API proxy calls use **`BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS`** (default **30**s).
- **`institutionBackendTimeoutSeconds()`**: New private helper plus named **`private const`** fallbacks (**300** / **30**) so defaults aren’t magic numbers scattered in the method.
- **`FileUpload.jsx`**: **`formatAxiosErrorMessage()`** derives a readable string from **`error`**, **`detail`**, **`message`**, or JSON fallbacks so users don’t see **`[Validation] undefined`** when Laravel/FastAPI use different response shapes. Upload / validate / signed-URL steps all use it.
- **Validate request**: **`axios.post(..., {}, { timeout: VALIDATE_UPLOAD_TIMEOUT_MS })`** (**300_000** ms) so the browser can wait as long as the validate proxy; constant documented to stay aligned with **`BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS`**.
- **`.env.example`**: Documents **`BACKEND_HTTP_DEFAULT_TIMEOUT_SECONDS`** and **`BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS`**.
- **`.github/workflows/precommit-tests.yml`**: Sets **`NODE_OPTIONS=--max-old-space-size=8192`** for **`npm run build`** so Vite is less likely to OOM on CI (and matches a successful local build pattern).

## context

Large course CSV validation can take **~60s+** on the API. Laravel’s HTTP client previously used the **default ~30s** timeout, so the **PHP proxy gave up** while Cloud Run still completed—users saw failures / **`undefined`** errors even when validation succeeded. This aligns proxy and browser wait times with validate-upload while keeping **short** timeouts for normal API traffic.

## questions

- None