### PR TITLE
feat: remove custom institution type; align create/edit with API school-type rules

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -174,6 +174,31 @@ class ApiController extends Controller
     }
 
     /**
+     * GET /institutions/{current inst_id} — details for the institution in session (edit form).
+     */
+    public function getCurrentInstitutionDetails(Request $request)
+    {
+        if (ApiController::isLocalRequest()) {
+            return response()->json([
+                'inst_id' => (string) ($request->attributes->get('inst_id') ?? ''),
+                'name' => 'Mock University',
+                'state' => 'NY',
+                'pdp_id' => '12345',
+                'edvise_id' => null,
+                'legacy_id' => null,
+                'retention_days' => null,
+            ], 200);
+        }
+
+        $resp = ApiController::constructInstRequest($request, '', 'GET', null);
+        if ($resp instanceof \Illuminate\Http\JsonResponse) {
+            return $resp;
+        }
+
+        return response()->json($resp->json(), $resp->status());
+    }
+
+    /**
      * HTTP client timeout (seconds) when proxying institution requests to BACKEND_URL.
      * Validate-upload needs a long wait for large CSV processing; other paths stay short.
      */

--- a/app/Http/Middleware/RequireInstitution.php
+++ b/app/Http/Middleware/RequireInstitution.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpFoundation\Response;
 class RequireInstitution
 {
     private const SKIP_ACTIONS = [
-        'createInstApi', 'addDatakinderApi', 'viewAllInstitutions', 'EditInstApi',
+        'createInstApi', 'addDatakinderApi', 'viewAllInstitutions',
     ];
 
     /** Route names (and patterns) that do not require an institution. */

--- a/resources/js/Pages/CreateInst.jsx
+++ b/resources/js/Pages/CreateInst.jsx
@@ -116,9 +116,15 @@ export default function CreateInst() {
       name: event.target.elements.inst_name.value,
       state: event.target.elements.state.value,
       allowed_emails:
-        constructedEmailDict.length == 0 ? null : constructedEmailDict,
+        Object.keys(constructedEmailDict).length === 0
+          ? null
+          : constructedEmailDict,
       is_pdp: pdp,
-      pdp_id: event.target.elements.pdp_id?.value || null,
+      // Only send PDP id when PDP is selected; leftover text would otherwise
+      // combine with Edvise/Legacy and trip API mutual-exclusivity checks.
+      pdp_id: pdpChecked
+        ? (event.target.elements.pdp_id?.value || null)
+        : null,
     };
     if (edvise) payload.is_edvise = true;
     if (legacy) payload.is_legacy = true;

--- a/resources/js/Pages/CreateInst.jsx
+++ b/resources/js/Pages/CreateInst.jsx
@@ -9,9 +9,7 @@ export default function CreateInst() {
   // TODO: switch to error instead of setting result_area
   const [error, setError] = useState(null);
 
-  // Any update to this schemas list needs to be reflected in the handleSubmit() function call as a checkbox.
   const schemas = [
-    { name: 'Custom', selected: false },
     { name: 'PDP', selected: false },
     { name: 'Edvise', selected: false },
     { name: 'Legacy', selected: false },
@@ -84,30 +82,17 @@ export default function CreateInst() {
         'Error: Institution name is required.';
       return;
     }
-    // Enforce the selection of at least one schema type.
     const edvise = event.target.elements.Edvise?.checked ?? false;
     const legacy = event.target.elements.Legacy?.checked ?? false;
-    if (
-      !event.target.elements.Custom.checked &&
-      !event.target.elements.PDP.checked &&
-      !edvise &&
-      !legacy
-    ) {
+    const pdpChecked = event.target.elements.PDP.checked;
+    const schoolTypeCount = [pdpChecked, edvise, legacy].filter(Boolean).length;
+    if (schoolTypeCount !== 1) {
       document.getElementById('result_area').innerHTML =
-        'Error: Schema type must contain at least one selection.';
+        schoolTypeCount === 0
+          ? 'Error: Select exactly one of PDP, Edvise, or Legacy.'
+          : 'Error: Select at most one of PDP, Edvise, or Legacy.';
       return;
     }
-    // At most one of PDP, Edvise, or Legacy (API allows only one school type).
-    const schoolTypeCount = [event.target.elements.PDP.checked, edvise, legacy].filter(Boolean).length;
-    if (schoolTypeCount > 1) {
-      document.getElementById('result_area').innerHTML =
-        'Error: Select at most one of PDP, Edvise, or Legacy.';
-      return;
-    }
-    // We currently only have custom for potential other schemas. Note that the schema passed to the API call must match the corresponding backend schema enum value.
-    let other_schemas = event.target.elements.Custom.checked
-      ? ['UNKNOWN']
-      : null;
     var emailDict = {};
     var accessDict = {};
     Array.from(event.target.elements).forEach(input => {
@@ -130,7 +115,6 @@ export default function CreateInst() {
     const payload = {
       name: event.target.elements.inst_name.value,
       state: event.target.elements.state.value,
-      allowed_schemas: other_schemas,
       allowed_emails:
         constructedEmailDict.length == 0 ? null : constructedEmailDict,
       is_pdp: pdp,
@@ -270,7 +254,7 @@ export default function CreateInst() {
               <div className="flex flex-col w-1/2">
                 <fieldset>
                   <legend className="text-base font-semibold text-gray-900">
-                    Schemas accepted by this institution
+                    Institution type
                   </legend>
                   <div className="mt-4 divide-y divide-gray-200 border-b border-t border-gray-200">
                     {schemas.map((schem, idx) => (

--- a/resources/js/Pages/CreateInst.jsx
+++ b/resources/js/Pages/CreateInst.jsx
@@ -1,31 +1,21 @@
 import React, { useState } from 'react';
 import AppLayout from '@/Layouts/AppLayout';
-import { TrashIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import HeaderLabel from '@/Components/HeaderLabel';
 import { Cog8ToothIcon } from '@heroicons/react/24/outline';
 
+const SCHOOL_TYPES = [
+  { value: 'pdp', label: 'PDP' },
+  { value: 'edvise', label: 'Edvise' },
+  { value: 'legacy', label: 'Legacy' },
+];
+
 export default function CreateInst() {
-  // TODO: switch to error instead of setting result_area
-  const [error, setError] = useState(null);
-
-  const schemas = [
-    { name: 'PDP', selected: false },
-    { name: 'Edvise', selected: false },
-    { name: 'Legacy', selected: false },
-  ];
-
+  const [schoolType, setSchoolType] = useState('');
   const [addUserCounter, setAddUserCounter] = useState(0);
 
-  // TODO implement remove additional email fields
-  const removeItem = itemId => {
-    const emailItem = document.getElementById(itemId);
-    emailItem.remove;
-  };
-
   const incrementCounter = () => {
-    const newId = addUserCounter + 1;
-    setAddUserCounter(newId);
+    setAddUserCounter(c => c + 1);
   };
 
   const renderFullEmailList = () => {
@@ -73,7 +63,6 @@ export default function CreateInst() {
 
   const handleSubmit = event => {
     event.preventDefault();
-    let pdp = event.target.elements.PDP.checked;
     if (
       event.target.elements.inst_name.value == null ||
       event.target.elements.inst_name.value == ''
@@ -82,16 +71,18 @@ export default function CreateInst() {
         'Error: Institution name is required.';
       return;
     }
-    const edvise = event.target.elements.Edvise?.checked ?? false;
-    const legacy = event.target.elements.Legacy?.checked ?? false;
-    const pdpChecked = event.target.elements.PDP.checked;
-    const schoolTypeCount = [pdpChecked, edvise, legacy].filter(Boolean).length;
-    if (schoolTypeCount !== 1) {
+    if (!schoolType) {
       document.getElementById('result_area').innerHTML =
-        schoolTypeCount === 0
-          ? 'Error: Select exactly one of PDP, Edvise, or Legacy.'
-          : 'Error: Select at most one of PDP, Edvise, or Legacy.';
+        'Error: Select exactly one of PDP, Edvise, or Legacy.';
       return;
+    }
+    if (schoolType === 'pdp') {
+      const raw = event.target.elements.pdp_id?.value?.trim() ?? '';
+      if (!raw) {
+        document.getElementById('result_area').innerHTML =
+          'Error: PDP Institution ID is required when PDP is selected.';
+        return;
+      }
     }
     var emailDict = {};
     var accessDict = {};
@@ -112,6 +103,7 @@ export default function CreateInst() {
         constructedEmailDict[value] = accessDict[key];
       }
     }
+    const pdpChecked = schoolType === 'pdp';
     const payload = {
       name: event.target.elements.inst_name.value,
       state: event.target.elements.state.value,
@@ -119,15 +111,13 @@ export default function CreateInst() {
         Object.keys(constructedEmailDict).length === 0
           ? null
           : constructedEmailDict,
-      is_pdp: pdp,
-      // Only send PDP id when PDP is selected; leftover text would otherwise
-      // combine with Edvise/Legacy and trip API mutual-exclusivity checks.
+      is_pdp: pdpChecked,
       pdp_id: pdpChecked
         ? (event.target.elements.pdp_id?.value || null)
         : null,
     };
-    if (edvise) payload.is_edvise = true;
-    if (legacy) payload.is_legacy = true;
+    if (schoolType === 'edvise') payload.is_edvise = true;
+    if (schoolType === 'legacy') payload.is_legacy = true;
     return axios({
       method: 'post',
       url: '/create-inst-api',
@@ -149,7 +139,6 @@ export default function CreateInst() {
       });
   };
 
-  // TODO check if the user is a datakinder, otherwise show an error page.
   return (
     <AppLayout
       title="Create Institution"
@@ -171,6 +160,7 @@ export default function CreateInst() {
         <form
           className="w-full max-w-full pl-36 pr-36 pt-24"
           onSubmit={handleSubmit}
+          onReset={() => setSchoolType('')}
         >
           <div id="form_contents" className="flex flex-col gap-y-6">
             <div className="flex flex-row w-full gap-x-6">
@@ -262,69 +252,56 @@ export default function CreateInst() {
                   <legend className="text-base font-semibold text-gray-900">
                     Institution type
                   </legend>
-                  <div className="mt-4 divide-y divide-gray-200 border-b border-t border-gray-200">
-                    {schemas.map((schem, idx) => (
-                      <div key={idx} className=" flex gap-3">
-                        <div className="min-w-0 flex-1 text-sm/6 ">
-                          <input
-                            defaultChecked={schem.selected}
-                            id={`${schem.name}`}
-                            name={`${schem.name}`}
-                            type="checkbox"
-                            className="col-start-1 row-start-1 appearance-none rounded border border-gray-300 bg-white checked:border-blue-600 checked:bg-blue-600 indeterminate:border-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto"
-                          />
-                          <label
-                            htmlFor={`${schem.name}`}
-                            className="m-2 select-none font-medium text-gray-900"
-                          >
-                            {schem.name}
-                          </label>
-                        </div>
-                        <div className="flex h-6 shrink-0 items-center">
-                          <div className="group grid size-4 grid-cols-1">
-                            <svg
-                              fill="none"
-                              viewBox="0 0 14 14"
-                              className="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-[:disabled]:stroke-gray-950/25"
-                            >
-                              <path
-                                d="M3 8L6 11L11 3.5"
-                                strokeWidth={2}
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                className="opacity-0 group-has-[:checked]:opacity-100"
-                              />
-                              <path
-                                d="M3 7H11"
-                                strokeWidth={2}
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                className="opacity-0 group-has-[:indeterminate]:opacity-100"
-                              />
-                            </svg>
-                          </div>
-                        </div>
+                  <p className="mt-1 text-sm text-gray-600">
+                    Choose exactly one. Required before submit.
+                  </p>
+                  <div className="mt-4 space-y-3 border-b border-t border-gray-200 py-3">
+                    {SCHOOL_TYPES.map(({ value, label }) => (
+                      <div key={value} className="flex gap-3 items-center">
+                        <input
+                          id={`school_type_${value}`}
+                          name="school_type"
+                          type="radio"
+                          value={value}
+                          checked={schoolType === value}
+                          onChange={() => setSchoolType(value)}
+                          className="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-600"
+                        />
+                        <label
+                          htmlFor={`school_type_${value}`}
+                          className="text-sm font-medium text-gray-900"
+                        >
+                          {label}
+                        </label>
                       </div>
                     ))}
                   </div>
                 </fieldset>
               </div>
               <div className="flex flex-col w-1/2">
-                <label
-                  className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-                  id="pdp_id"
-                >
-                  PDP Institution ID
-                </label>
-                <input
-                  name="pdp_id"
-                  className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
-                  type="text"
-                ></input>
-                <p className="text-gray-600 text-xs italic">
-                  For PDP schools, please add the PDP_INST id of the
-                  institution. Include any leading zeroes.
-                </p>
+                {schoolType === 'pdp' ? (
+                  <>
+                    <label
+                      className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
+                      id="pdp_id"
+                    >
+                      PDP Institution ID
+                    </label>
+                    <input
+                      name="pdp_id"
+                      className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+                      type="text"
+                    ></input>
+                    <p className="text-gray-600 text-xs italic">
+                      For PDP schools, please add the PDP_INST id of the
+                      institution. Include any leading zeroes.
+                    </p>
+                  </>
+                ) : (
+                  <p className="text-gray-600 text-sm">
+                    PDP Institution ID applies only when PDP is selected.
+                  </p>
+                )}
               </div>
             </div>
             <div id="mult_users" className="flex flex-col">

--- a/resources/js/Pages/EditInst.jsx
+++ b/resources/js/Pages/EditInst.jsx
@@ -1,33 +1,73 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import AppLayout from '@/Layouts/AppLayout';
-import { TrashIcon } from '@heroicons/react/24/outline';
 import axios from 'axios';
 import HeaderLabel from '@/Components/HeaderLabel';
 import { Cog8ToothIcon } from '@heroicons/react/24/outline';
+import { Link, usePage } from '@inertiajs/react';
 
 const US_STATES = [
   'AK', 'AL', 'AR', 'AZ', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
   'HI', 'IA', 'ID', 'IL', 'IN', 'KS', 'KY', 'LA', 'MA', 'MD',
   'ME', 'MI', 'MN', 'MO', 'MS', 'MT', 'NC', 'ND', 'NE', 'NH',
   'NJ', 'NM', 'NV', 'NY', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
-  'SD', 'TN', 'TX', 'UT', 'VA', 'VT', 'WA', 'WI', 'WV', 'WY'
+  'SD', 'TN', 'TX', 'UT', 'VA', 'VT', 'WA', 'WI', 'WV', 'WY',
 ];
 
+const SCHOOL_TYPES = [
+  { value: 'pdp', label: 'PDP' },
+  { value: 'edvise', label: 'Edvise' },
+  { value: 'legacy', label: 'Legacy' },
+];
+
+function schoolTypeFromInst(inst) {
+  if (!inst) return '';
+  if (inst.pdp_id) return 'pdp';
+  if (inst.edvise_id) return 'edvise';
+  if (inst.legacy_id) return 'legacy';
+  return '';
+}
+
 export default function EditInst() {
+  const { inst_id: pageInstId } = usePage().props;
+
   const [error, setError] = useState(null);
   const [addUserCounter, setAddUserCounter] = useState(1);
-  const [schemas] = useState([
-    { name: 'PDP', selected: false },
-    { name: 'Edvise', selected: false },
-    { name: 'Legacy', selected: false },
-  ]);
+  const [inst, setInst] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [schoolType, setSchoolType] = useState('');
+  const [formGeneration, setFormGeneration] = useState(0);
 
-  const removeItem = (itemId) => {
-    const emailItem = document.getElementById(itemId);
-    if (emailItem) {
-      emailItem.remove();
+  const loadInstitution = useCallback(() => {
+    if (!pageInstId) {
+      setLoadError('Set an institution before editing.');
+      setLoading(false);
+      setInst(null);
+      return;
     }
-  };
+    setLoading(true);
+    setLoadError(null);
+    return axios
+      .get('/current-institution-api')
+      .then(res => {
+        setInst(res.data);
+        setSchoolType(schoolTypeFromInst(res.data));
+        setError(null);
+      })
+      .catch(err => {
+        setInst(null);
+        setLoadError(
+          err.response?.data?.error ??
+            err.message ??
+            'Failed to load institution.',
+        );
+      })
+      .finally(() => setLoading(false));
+  }, [pageInstId]);
+
+  useEffect(() => {
+    loadInstitution();
+  }, [loadInstitution]);
 
   const incrementCounter = () => {
     setAddUserCounter(prev => prev + 1);
@@ -36,10 +76,9 @@ export default function EditInst() {
   const resetForm = () => {
     setAddUserCounter(1);
     setError(null);
-    schemas.forEach(schema => schema.selected = false);
-    const form = document.getElementById('edit-institution-form');
-    if (form) {
-      form.reset();
+    setFormGeneration(g => g + 1);
+    if (inst) {
+      setSchoolType(schoolTypeFromInst(inst));
     }
   };
 
@@ -49,7 +88,6 @@ export default function EditInst() {
     ).slice(1);
     return (
       <div>
-        {/* Default first row */}
         <div id="default_user" className="flex">
           <div className="w-1/2">
             <label className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2">
@@ -78,19 +116,15 @@ export default function EditInst() {
           </div>
         </div>
 
-        {/* Additional rows */}
         {arrOfAllAddedEmailSlots.map(id => (
           <div id="one_user" className="flex">
             <div className="w-1/2">
-              <label
-                className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-                id="access"
-              >
+              <label className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2">
                 Access Type
               </label>
               <div className="relative">
                 <select
-                  name={id + '-access'}
+                  name={`${id}-access`}
                   className="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
                 >
                   <option>MODEL_OWNER</option>
@@ -99,18 +133,15 @@ export default function EditInst() {
               </div>
             </div>
             <div className="w-1/2 px-3 mb-6">
-              <label
-                className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-                id="email"
-              >
+              <label className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2">
                 User email
               </label>
               <input
-                name={id + '-email'}
+                name={`${id}-email`}
                 className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
                 type="email"
                 placeholder="j.smith@inst1.edu"
-              ></input>
+              />
             </div>
           </div>
         ))}
@@ -118,33 +149,78 @@ export default function EditInst() {
     );
   };
 
-  const handleSubmit = async (event) => {
+  const handleSubmit = async event => {
     event.preventDefault();
     const formData = new FormData(event.target);
-    const pdp = formData.get('PDP') === 'on';
-    const edvise = formData.get('Edvise') === 'on';
-    const legacy = formData.get('Legacy') === 'on';
-    const schoolTypeCount = [pdp, edvise, legacy].filter(Boolean).length;
-    if (schoolTypeCount > 1) {
-      setError('Select at most one of PDP, Edvise, or Legacy.');
+    const type = schoolType || formData.get('school_type');
+    if (!type) {
+      setError('Select exactly one of PDP, Edvise, or Legacy.');
       return;
     }
-    // API only updates fields that are sent; to clear a school type we must send null explicitly.
-    // Omit edvise_id/legacy_id when that type is selected (no input to set; preserve existing).
+    if (type === 'pdp') {
+      const pid = (formData.get('pdp_id') || '').trim();
+      if (!pid) {
+        setError('PDP Institution ID is required when PDP is selected.');
+        return;
+      }
+    }
+
+    var emailDict = {};
+    var accessDict = {};
+    Array.from(event.target.elements).forEach(input => {
+      if (input.name.endsWith('-access') || input.name.endsWith('-email')) {
+        let idx = Array.from(input.name)[0];
+        if (input.name.endsWith('-access')) {
+          accessDict[idx] = input.value;
+        } else {
+          emailDict[idx] = input.value;
+        }
+      }
+    });
+    var constructedEmailDict = {};
+    for (const [key, value] of Object.entries(emailDict)) {
+      if (value != null && value != '') {
+        constructedEmailDict[value] = accessDict[key];
+      }
+    }
+
     const payload = {
       name: formData.get('inst_name'),
-      state: formData.get('state'),
-      allowed_emails: constructEmailDict(formData),
-      is_pdp: pdp,
-      pdp_id: pdp ? (formData.get('pdp_id') || null) : null,
-      edvise_id: edvise ? undefined : null, // omit when Edvise so API keeps existing; null clears
-      legacy_id: legacy ? undefined : null,  // omit when Legacy so API keeps existing; null clears
+      state: formData.get('state') || null,
+      allowed_emails:
+        Object.keys(constructedEmailDict).length === 0
+          ? null
+          : constructedEmailDict,
     };
-    if (edvise) payload.is_edvise = true;
-    if (legacy) payload.is_legacy = true;
+
+    if (type === 'pdp') {
+      payload.is_pdp = true;
+      payload.pdp_id = (formData.get('pdp_id') || '').trim();
+      payload.edvise_id = null;
+      payload.legacy_id = null;
+    } else if (type === 'edvise') {
+      payload.is_edvise = true;
+      payload.pdp_id = null;
+      payload.legacy_id = null;
+      const eid = (formData.get('edvise_id') || '').trim();
+      if (eid) {
+        payload.edvise_id = eid;
+      }
+    } else if (type === 'legacy') {
+      payload.is_legacy = true;
+      payload.pdp_id = null;
+      payload.edvise_id = null;
+      const lid = (formData.get('legacy_id') || '').trim();
+      if (lid) {
+        payload.legacy_id = lid;
+      }
+    }
+
     try {
       await axios.post('/edit-inst-api', payload);
       setError(null);
+      await loadInstitution();
+      setFormGeneration(g => g + 1);
     } catch (err) {
       setError(err.response?.data?.error || err.message);
     }
@@ -167,153 +243,212 @@ export default function EditInst() {
           }
           majorTitle="Admin Actions"
           minorTitle="Edit Institution [Do not use: Work in progress]"
-        ></HeaderLabel>
-        <form
-          id="edit-institution-form"
-          className="w-full max-w-full pl-36 pr-36 pt-24"
-          onSubmit={handleSubmit}
-        >
-          <div id="form_contents" className="flex flex-col gap-y-6">
-            <div className="flex flex-row w-full gap-x-6">
-              <div className="flex flex-col w-2/3">
-                <label
-                  className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-                  id="inst_name"
-                >
-                  Institution Name
-                </label>
-                <input
-                  name="inst_name"
-                  className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white cursor-not-allowed"
-                  type="text"
-                  value="Placeholder for institution name"
-                  disabled
-                />
-              </div>
-              <div className="flex flex-col w-1/3">
-                <label
-                  className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-                  id="state"
-                >
-                  State
-                </label>
-                <div className="relative">
-                  <select
-                    name="state"
-                    className="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+        />
+        {loading && (
+          <p className="mt-8 text-gray-600">Loading institution…</p>
+        )}
+        {!loading && loadError && (
+          <div className="mt-8 max-w-lg text-center text-red-600">
+            <p>{loadError}</p>
+            {!pageInstId && (
+              <Link
+                href="/set-inst"
+                className="mt-4 inline-block text-blue-600 underline"
+              >
+                Set institution
+              </Link>
+            )}
+          </div>
+        )}
+        {!loading && !loadError && inst && (
+          <form
+            id="edit-institution-form"
+            key={`${inst.inst_id}-${formGeneration}`}
+            className="w-full max-w-full pl-36 pr-36 pt-24"
+            onSubmit={handleSubmit}
+          >
+            <div id="form_contents" className="flex flex-col gap-y-6">
+              <div className="flex flex-row w-full gap-x-6">
+                <div className="flex flex-col w-2/3">
+                  <label
+                    className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
+                    htmlFor="edit_inst_name"
                   >
-                    <option defaultValue></option>
-                    {US_STATES.map(state => (
-                      <option key={state} value={state}>{state}</option>
-                    ))}
-                  </select>
+                    Institution Name
+                  </label>
+                  <input
+                    id="edit_inst_name"
+                    name="inst_name"
+                    className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white cursor-not-allowed"
+                    type="text"
+                    defaultValue={inst.name}
+                    readOnly
+                  />
+                </div>
+                <div className="flex flex-col w-1/3">
+                  <label
+                    className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
+                    htmlFor="edit_state"
+                  >
+                    State
+                  </label>
+                  <div className="relative">
+                    <select
+                      id="edit_state"
+                      name="state"
+                      className="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+                      defaultValue={inst.state ?? ''}
+                    >
+                      <option value=""> </option>
+                      {US_STATES.map(state => (
+                        <option key={state} value={state}>
+                          {state}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div className="flex flex-row w-full gap-x-6">
-              <div className="flex flex-col w-1/2">
-                <fieldset>
-                  <legend className="text-base font-semibold text-gray-900">
-                    Institution type
-                  </legend>
-                  <div className="mt-4 divide-y divide-gray-200 border-b border-t border-gray-200">
-                    {schemas.map((schem, idx) => (
-                      <div key={idx} className=" flex gap-3">
-                        <div className="min-w-0 flex-1 text-sm/6 ">
+              <div className="flex flex-row w-full gap-x-6">
+                <div className="flex flex-col w-1/2">
+                  <fieldset>
+                    <legend className="text-base font-semibold text-gray-900">
+                      Institution type
+                    </legend>
+                    <p className="mt-1 text-sm text-gray-600">
+                      Choose exactly one.
+                    </p>
+                    <div className="mt-4 space-y-3 border-b border-t border-gray-200 py-3">
+                      {SCHOOL_TYPES.map(({ value, label }) => (
+                        <div key={value} className="flex gap-3 items-center">
                           <input
-                            defaultChecked={schem.selected}
-                            id={`${schem.name}`}
-                            name={`${schem.name}`}
-                            type="checkbox"
-                            className="col-start-1 row-start-1 appearance-none rounded border border-gray-300 bg-white checked:border-blue-600 checked:bg-blue-600 indeterminate:border-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:border-gray-300 disabled:bg-gray-100 disabled:checked:bg-gray-100 forced-colors:appearance-auto"
+                            id={`edit_school_type_${value}`}
+                            name="school_type"
+                            type="radio"
+                            value={value}
+                            checked={schoolType === value}
+                            onChange={() => setSchoolType(value)}
+                            className="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-600"
                           />
                           <label
-                            htmlFor={`${schem.name}`}
-                            className="m-2 select-none font-medium text-gray-900"
+                            htmlFor={`edit_school_type_${value}`}
+                            className="text-sm font-medium text-gray-900"
                           >
-                            {schem.name}
+                            {label}
                           </label>
                         </div>
-                        <div className="flex h-6 shrink-0 items-center">
-                          <div className="group grid size-4 grid-cols-1">
-                            <svg
-                              fill="none"
-                              viewBox="0 0 14 14"
-                              className="pointer-events-none col-start-1 row-start-1 size-3.5 self-center justify-self-center stroke-white group-has-[:disabled]:stroke-gray-950/25"
-                            >
-                              <path
-                                d="M3 8L6 11L11 3.5"
-                                strokeWidth={2}
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                className="opacity-0 group-has-[:checked]:opacity-100"
-                              />
-                              <path
-                                d="M3 7H11"
-                                strokeWidth={2}
-                                strokeLinecap="round"
-                                strokeLinejoin="round"
-                                className="opacity-0 group-has-[:indeterminate]:opacity-100"
-                              />
-                            </svg>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </fieldset>
+                      ))}
+                    </div>
+                  </fieldset>
+                </div>
+                <div className="flex flex-col w-1/2 gap-4">
+                  {schoolType === 'pdp' && (
+                    <div>
+                      <label
+                        className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
+                        htmlFor="edit_pdp_id"
+                      >
+                        PDP Institution ID
+                      </label>
+                      <input
+                        id="edit_pdp_id"
+                        name="pdp_id"
+                        key={`pdp-${formGeneration}`}
+                        defaultValue={inst.pdp_id ?? ''}
+                        className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+                        type="text"
+                      />
+                      <p className="text-gray-600 text-xs italic">
+                        For PDP schools, please add the PDP_INST id of the
+                        institution. Include any leading zeroes.
+                      </p>
+                    </div>
+                  )}
+                  {schoolType === 'edvise' && (
+                    <div>
+                      <label
+                        className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
+                        htmlFor="edit_edvise_id"
+                      >
+                        Edvise ID (optional)
+                      </label>
+                      <input
+                        id="edit_edvise_id"
+                        name="edvise_id"
+                        key={`edvise-${formGeneration}`}
+                        defaultValue={inst.edvise_id ?? ''}
+                        className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+                        type="text"
+                      />
+                      <p className="text-gray-600 text-xs italic">
+                        Leave blank to keep the current Edvise id, or set when
+                        switching to Edvise to choose a specific id.
+                      </p>
+                    </div>
+                  )}
+                  {schoolType === 'legacy' && (
+                    <div>
+                      <label
+                        className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
+                        htmlFor="edit_legacy_id"
+                      >
+                        Legacy ID (optional)
+                      </label>
+                      <input
+                        id="edit_legacy_id"
+                        name="legacy_id"
+                        key={`legacy-${formGeneration}`}
+                        defaultValue={inst.legacy_id ?? ''}
+                        className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
+                        type="text"
+                      />
+                      <p className="text-gray-600 text-xs italic">
+                        Leave blank to keep the current Legacy id, or set when
+                        switching to Legacy to choose a specific id.
+                      </p>
+                    </div>
+                  )}
+                  {schoolType === '' && (
+                    <p className="text-gray-600 text-sm">
+                      Select a type to edit identifiers.
+                    </p>
+                  )}
+                </div>
               </div>
-              <div className="flex flex-col w-1/2">
-                <label
-                  className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-                  id="pdp_id"
-                >
-                  PDP Institution ID
-                </label>
-                <input
-                  name="pdp_id"
-                  className="appearance-none block w-full bg-gray-200 text-gray-700 border border-gray-200 rounded py-3 px-4 mb-3 leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
-                  type="text"
-                ></input>
-                <p className="text-gray-600 text-xs italic">
-                  For PDP schools, please add the PDP_INST id of the
-                  institution. Include any leading zeroes.
-                </p>
+              <div id="mult_users" className="flex flex-col">
+                {renderFullEmailList()}
               </div>
             </div>
-            <div id="mult_users" className="flex flex-col">
-              {renderFullEmailList()}
+            <div className="flex w-full justify-center">
+              <button
+                id="button_add_field"
+                type="button"
+                className="flex bg-gray-200 text-gray-700 py-2 px-3 rounded-lg mb-4 justify-center items-center w-1/3"
+                onClick={incrementCounter}
+              >
+                Add Another Email
+              </button>
             </div>
-          </div>
-          <div className="flex w-full justify-center">
-            <button
-              id="button_add_field"
-              type="button"
-              className="flex bg-gray-200 text-gray-700 py-2 px-3 rounded-lg mb-4 justify-center items-center w-1/3"
-              onClick={incrementCounter}
-            >
-              Add Another Email
-            </button>
-          </div>
-          <div className="flex w-full justify-center pt-12 gap-x-6">
-            <button
-              type="button"
-              onClick={resetForm}
-              className="flex bg-white text-[#f79222] border border-[#f79222] py-2 px-3 rounded-lg mb-4 justify-center items-center w-1/3"
-            >
-              Reset
-            </button>
-            <button
-              type="submit"
-              className="flex bg-[#f79222] text-white py-2 px-3 rounded-lg mb-4 justify-center items-center w-1/3"
-            >
-              Submit
-            </button>
-          </div>
-        </form>
+            <div className="flex w-full justify-center pt-12 gap-x-6">
+              <button
+                type="button"
+                onClick={resetForm}
+                className="flex bg-white text-[#f79222] border border-[#f79222] py-2 px-3 rounded-lg mb-4 justify-center items-center w-1/3"
+              >
+                Reset
+              </button>
+              <button
+                type="submit"
+                className="flex bg-[#f79222] text-white py-2 px-3 rounded-lg mb-4 justify-center items-center w-1/3"
+              >
+                Submit
+              </button>
+            </div>
+          </form>
+        )}
         {error && (
-          <div className="text-red-500 mt-4">
-            {error}
+          <div className="text-red-500 mt-4 max-w-2xl text-center px-6">
+            {typeof error === 'string' ? error : JSON.stringify(error)}
           </div>
         )}
         <div id="result_area" className="flex pb-24 pt-12"></div>

--- a/resources/js/Pages/EditInst.jsx
+++ b/resources/js/Pages/EditInst.jsx
@@ -17,7 +17,6 @@ export default function EditInst() {
   const [error, setError] = useState(null);
   const [addUserCounter, setAddUserCounter] = useState(1);
   const [schemas] = useState([
-    { name: 'Custom', selected: false },
     { name: 'PDP', selected: false },
     { name: 'Edvise', selected: false },
     { name: 'Legacy', selected: false },
@@ -135,7 +134,6 @@ export default function EditInst() {
     const payload = {
       name: formData.get('inst_name'),
       state: formData.get('state'),
-      allowed_schemas: formData.get('Custom') ? ['UNKNOWN'] : null,
       allowed_emails: constructEmailDict(formData),
       is_pdp: pdp,
       pdp_id: pdp ? (formData.get('pdp_id') || null) : null,
@@ -216,7 +214,7 @@ export default function EditInst() {
               <div className="flex flex-col w-1/2">
                 <fieldset>
                   <legend className="text-base font-semibold text-gray-900">
-                    Schemas accepted by this institution
+                    Institution type
                   </legend>
                   <div className="mt-4 divide-y divide-gray-200 border-b border-t border-gray-200">
                     {schemas.map((schem, idx) => (

--- a/resources/js/Pages/EditInst.jsx
+++ b/resources/js/Pages/EditInst.jsx
@@ -125,8 +125,12 @@ export default function EditInst() {
     const edvise = formData.get('Edvise') === 'on';
     const legacy = formData.get('Legacy') === 'on';
     const schoolTypeCount = [pdp, edvise, legacy].filter(Boolean).length;
-    if (schoolTypeCount > 1) {
-      setError('Select at most one of PDP, Edvise, or Legacy.');
+    if (schoolTypeCount !== 1) {
+      setError(
+        schoolTypeCount === 0
+          ? 'Select exactly one of PDP, Edvise, or Legacy.'
+          : 'Select at most one of PDP, Edvise, or Legacy.',
+      );
       return;
     }
     // API only updates fields that are sent; to clear a school type we must send null explicitly.

--- a/resources/js/Pages/EditInst.jsx
+++ b/resources/js/Pages/EditInst.jsx
@@ -125,12 +125,8 @@ export default function EditInst() {
     const edvise = formData.get('Edvise') === 'on';
     const legacy = formData.get('Legacy') === 'on';
     const schoolTypeCount = [pdp, edvise, legacy].filter(Boolean).length;
-    if (schoolTypeCount !== 1) {
-      setError(
-        schoolTypeCount === 0
-          ? 'Select exactly one of PDP, Edvise, or Legacy.'
-          : 'Select at most one of PDP, Edvise, or Legacy.',
-      );
+    if (schoolTypeCount > 1) {
+      setError('Select at most one of PDP, Edvise, or Legacy.');
       return;
     }
     // API only updates fields that are sent; to clear a school type we must send null explicitly.

--- a/routes/web.php
+++ b/routes/web.php
@@ -156,6 +156,7 @@ Route::middleware(['auth', 'datakinder', 'terms.accepted'])->group(function () {
     Route::post('/edit-inst-api', [ApiController::class, 'EditInstApi']);
     Route::post('/add-dk-api', [ApiController::class, 'addDatakinderApi']);
     Route::get('/view-all-institutions-api', [ApiController::class, 'viewAllInstitutions']);
+    Route::get('/current-institution-api', [ApiController::class, 'getCurrentInstitutionDetails']);
 
     Route::get('/create-inst', function () {
         return Inertia::render('CreateInst');


### PR DESCRIPTION
<!--- Provide a brief description of your changes in the title above. -->

## changes
<!--- Describe your changes in detail, to guide reviewers through the git diff. -->

- **Create / edit institution flows**
  - Remove **Custom** as an institution type in the UI.
  - Align forms with API rules: **exactly one** of PDP / Edvise (ES) / Legacy; conditional fields (e.g. `pdp_id` only when PDP); schema / allowed-email handling consistent with the hardened API (Avoid client-driven allowed_schemas that mixed custom behavior with UNKNOWN; school type + API schema groups are the source of truth

## context
<!--- Why are these change required? What problem does it solve? -->
<!--- If this fixes an open issue / is ticketed, put the link(s) here! -->

The backend is dropping custom institutions; the admin UI must not offer Custom and must send payloads the API accepts. This pairs with the **edvise-api** PR - https://github.com/datakind/edvise-api/pull/228

https://app.asana.com/1/6325821815997/project/1208486153653829/task/1213791624909790?focus=true

## testing
Tested deployed feature branch on dev with its associated edvise-api feature branch: confirmed that custom is removed and that school creation is working as intended.

## questions
<!--- Ask any specific questions that you'd like reviewers to address. -->

- None

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213998619119563