### PR TITLE
fix: post-merge regressions (missing GetinstitutionId + Plotly)

### DIFF
--- a/app/Http/Middleware/RequireInstitution.php
+++ b/app/Http/Middleware/RequireInstitution.php
@@ -32,7 +32,7 @@ class RequireInstitution
         }
 
         if ($request->user()->access_type !== 'DATAKINDER') {
-            [$inst, ] = InstitutionHelper::GetInstitutionId($request);
+            [$inst, ] = InstitutionHelper::GetInstitution($request);
             if ($inst !== null && $inst !== '') {
                 $institution = session('institution');
                 if (is_array($institution) && ! empty($institution['inst_id'] ?? '')) {
@@ -62,7 +62,7 @@ class RequireInstitution
             }
         }
 
-        [$inst, $instErr] = InstitutionHelper::GetInstitutionId($request);
+        [$inst, $instErr] = InstitutionHelper::GetInstitution($request);
         if ($inst !== null && $inst !== '') {
             $institution = session('institution');
             if (is_array($institution) && ! empty($institution['inst_id'] ?? '')) {

--- a/resources/js/Components/Shap.jsx
+++ b/resources/js/Components/Shap.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useEffect } from 'react';
-import Plot from 'react-plotly.js';
+import Plot from '@/utils/reactPlotly';
 import PropTypes from 'prop-types';
 
 export default function Shap({ rawFeatures, currentFeature }) {

--- a/resources/js/Components/SupportOverview.jsx
+++ b/resources/js/Components/SupportOverview.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { usePage } from '@inertiajs/react';
-import Plot from 'react-plotly.js';
+import Plot from '@/utils/reactPlotly';
 import axios from 'axios';
 import H2 from '@/Components/H2';
 

--- a/resources/js/Components/SupportScores.jsx
+++ b/resources/js/Components/SupportScores.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import Plot from 'react-plotly.js';
+import Plot from '@/utils/reactPlotly';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import H2 from '@/Components/H2';

--- a/resources/js/Pages/ModelResultsOverview.jsx
+++ b/resources/js/Pages/ModelResultsOverview.jsx
@@ -285,7 +285,7 @@ function ModelResultsOverview({
                             key={feature.feature_readable_name}
                             className={`border-b border-[#E5E7EB] align-top last:border-b-0 ${idx % 2 === 1 ? 'bg-[#F7F9FB]' : ''}`}
                           >
-                            <td className="w-1/3 border-b border-r border-t border-[#e5e7eb] border-r-[#CDCDCD] py-3 pl-4 pr-4">
+                            <td className="w-1/3 border-t border-r border-b border-[#e5e7eb] border-r-[#CDCDCD] py-3 pr-4 pl-4">
                               <div
                                 className="cursor-pointer text-2xl font-light text-[#007C8C] hover:underline"
                                 onClick={() => handleFeatureClick(feature)}
@@ -298,7 +298,7 @@ function ModelResultsOverview({
                                 {feature.feature_short_desc}
                               </div>
                             </td>
-                            <td className="w-2/3 border-b border-t border-[#e5e7eb] py-3">
+                            <td className="w-2/3 border-t border-b border-[#e5e7eb] py-3">
                               <Shap
                                 rawFeatures={rawFeatures}
                                 currentFeature={feature}
@@ -390,7 +390,10 @@ function ModelResultsOverview({
                 </div>
                 <div className="mb-8">
                   {/* Feature Value Table */}
-                  <FeatureValue model_run_id={model_run_id} inst_id={institution?.inst_id} />
+                  <FeatureValue
+                    model_run_id={model_run_id}
+                    inst_id={institution?.inst_id}
+                  />
                 </div>
                 {/* Confusion Matrix */}
                 <div className="mb-8">
@@ -427,13 +430,13 @@ function ModelResultsOverview({
       {isModalOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div
-            className="fixed inset-0 bg-black bg-opacity-80"
+            className="bg-opacity-80 fixed inset-0 bg-black"
             onClick={closeModal}
           ></div>
           <div className="relative mx-4 max-h-[90vh] w-full max-w-4xl overflow-y-auto rounded-lg border border-2 border-[#F79122] bg-white shadow-xl">
             <button
               onClick={closeModal}
-              className="absolute right-4 top-4 text-black hover:opacity-80"
+              className="absolute top-4 right-4 text-black hover:opacity-80"
               aria-label="Close modal"
             >
               <svg

--- a/resources/js/Pages/ModelResultsOverview.jsx
+++ b/resources/js/Pages/ModelResultsOverview.jsx
@@ -376,7 +376,7 @@ function ModelResultsOverview({
                     demonstrate the performance of the model. You can also{' '}
                     <a
                       href={modelCardDownloadUrl(
-                        inst_id,
+                        institution?.inst_id,
                         model_run_id,
                         modelName,
                       )}

--- a/resources/js/utils/reactPlotly.js
+++ b/resources/js/utils/reactPlotly.js
@@ -1,0 +1,3 @@
+import mod from 'react-plotly.js';
+
+export default mod?.default ?? mod;


### PR DESCRIPTION
### Asana Task
[EDVISEWEBAPP-472: Fix undefined App\Helpers\InstitutionHelper::GetInstitutionId()](https://app.asana.com/0/0/task/1214107382565443)

### Summary
Repairs breakages after the develop merge: middleware still called removed `GetInstitutionId`, Model Results referenced an undefined `inst_id`, and `react-plotly.js`’s default export under Vite resolved to a module object instead of a component.

### Changes
- **`RequireInstitution`**: call `InstitutionHelper::GetInstitution()` (same `[id, error]` shape as the old helper).
- **`ModelResultsOverview`**: use `institution?.inst_id` for the model card download URL.
- **Charts**: add `resources/js/utils/reactPlotly.js` (`default` unwrap) and import it from `Shap`, `SupportScores`, and `SupportOverview`.

### How to test
- Log in with institution context; hit routes that use `RequireInstitution` (no server error).
- Open **Model Results** → page loads; “download the model card” link does not throw.
- Open tabs that render SHAP / support charts → no React “invalid element type: object” warning; plots render.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214107382565443