### PR TITLE
fix: do not write empty institution id when check-self has none (DataKinder path)

### DIFF
--- a/app/Helpers/InstitutionHelper.php
+++ b/app/Helpers/InstitutionHelper.php
@@ -33,15 +33,22 @@ class InstitutionHelper
             return;
         }
         $accessType = $resp['access_type'] ?? '';
+        $instIdFromApi = (string) ($resp['inst_id'] ?? '');
+        $update = ['access_type' => $accessType];
+        if ($instIdFromApi !== '') {
+            $update['inst_id'] = $instIdFromApi;
+        }
         DB::table('users')
             ->where('email', $request->user()->email)
-            ->update(['access_type' => $accessType, 'inst_id' => $resp['inst_id']]);
+            ->update($update);
         $request->user()->access_type = $accessType;
-        $request->user()->inst_id = $resp['inst_id'];
+        if ($instIdFromApi !== '') {
+            $request->user()->inst_id = $instIdFromApi;
+        }
 
-        if ($accessType !== 'DATAKINDER' && ($resp['inst_id'] ?? '') !== '') {
-            $full = self::fetchInstitutionById($request, $resp['inst_id']);
-            session(['institution' => $full ?? ['inst_id' => $resp['inst_id']]]);
+        if ($accessType !== 'DATAKINDER' && $instIdFromApi !== '') {
+            $full = self::fetchInstitutionById($request, $instIdFromApi);
+            session(['institution' => $full ?? ['inst_id' => $instIdFromApi]]);
         }
     }
 


### PR DESCRIPTION
## Summary

After login we call `/check-self` and persist the result on `users`. The handler always sent `access_type` and `inst_id` in the same `UPDATE`. When the API returned an empty institution id (common for DataKinder), that still updated `inst_id` and could produce a value the database rejected under a foreign key from `users.inst_id` to `inst.id`, causing a failed login.

## Changes

- **`InstitutionHelper::syncUserFromBackend`:** Add `inst_id` to the `UPDATE` and assign it on the authenticated user only when `/check-self` returns a non-empty `inst_id`. Keep syncing `access_type` in this path as before.

## Verification

- Log in using Google SSO with a user with DATAKINDER role.

## Questions

- **Who owns the `users` (and `inst`) schema?** Migrations in `edvise-ui` create part of the picture; the API in `edvise-api` also models the same tables and uses `Base.metadata.create_all` at startup, so a single “source of truth” for all constraints may not be obvious. Should we document which repo must run first, whether operational DDL in Cloud SQL is allowed, and how a new environment is supposed to get the same `users` definition as dev?

- **Environmental Parity** This is another example of disjointed local and dev environments causing issues. In this case, a foreign key constraint on the users table in dev did not appear in local. This caused the bug to be introduced, as well as made it much more time-consuming to identify and fix. Should we dedicate more resources to the unglamorous task of achieving true environmental parity?


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214194284177723