### PR TITLE
feat: remove upload timeout

### DIFF
--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -531,7 +531,6 @@ export default function FileUpload() {
     //setValidationResults({});
     let localValidationResults = {};
 
-    // Override axios default (120s in bootstrap.ts): slow/large direct-to-GCS uploads need no cap.
     const config = {
       headers: {
         'Content-Type': 'text/csv',

--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -534,10 +534,12 @@ export default function FileUpload() {
     //setValidationResults({});
     let localValidationResults = {};
 
+    // Override axios default (120s in bootstrap.ts): slow/large direct-to-GCS uploads need no cap.
     const config = {
       headers: {
         'Content-Type': 'text/csv',
       },
+      timeout: 0,
     };
     Promise.allSettled(
       files.map(file => {

--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -15,9 +15,6 @@ import BigSuccessAlert from '@/Components/BigSuccessAlert';
 import Alert from '@/Components/Alert';
 import Spinner from '@/Components/Spinner';
 
-/** Keep in sync with BACKEND_HTTP_VALIDATE_TIMEOUT_SECONDS (seconds) on the Laravel proxy. */
-const VALIDATE_UPLOAD_TIMEOUT_MS = 300_000;
-
 /**
  * Build a human-readable message from an axios error (Laravel `error`, FastAPI `detail`, etc.).
  * @param {unknown} error

--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -96,7 +96,7 @@ export default function FileUpload() {
       let msg =
         '[ERROR] Prediction trigger failed: ' + predictionResults['error'];
       return (
-        <div className="flex flex-col pl-24 pr-24">
+        <div className="flex flex-col pr-24 pl-24">
           <Alert variant="danger" mainMsg={msg} />
         </div>
       );
@@ -121,7 +121,7 @@ export default function FileUpload() {
     if (batchCreationResult !== 'ok') {
       let msg = '[ERROR] Batch creation failed: ' + batchCreationResult;
       return (
-        <div className="flex flex-col pl-24 pr-24">
+        <div className="flex flex-col pr-24 pl-24">
           <Alert variant="danger" mainMsg={msg} />
           <div className="flex w-full flex-row items-end justify-between pt-48">
             <Link
@@ -166,7 +166,7 @@ export default function FileUpload() {
     }
     if (Object.values(validationResults).find(element => element !== 'ok')) {
       return (
-        <div className="flex flex-col pl-24 pr-24">
+        <div className="flex flex-col pr-24 pl-24">
           <Alert
             variant="danger"
             mainMsg="[ERROR] The following files must be re-uploaded"

--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -562,7 +562,7 @@ export default function FileUpload() {
                   .post(
                     '/file-validate-api/' + filenameConstructed,
                     {},
-                    { timeout: VALIDATE_UPLOAD_TIMEOUT_MS },
+                    { timeout: 0 },
                   )
                   .then(res2 => {
                     localValidationResults[filenameConstructed] = 'ok';


### PR DESCRIPTION
## Changes ##
Remove the timeouts for Upload Data actions

## Context ##
- Uploads were not being completed due to timeouts in uploading files to Google Cloud Storage and performing file validations
- The issue was reported when uploading 7 files totaling over 300MB of data on a 10Mbps upload connection

## Future Plans ##
Add a progress bar to give the user feedback during file uploads

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214305131293195