### PR TITLE
feat(eda): add optional clear-cache=1 to /eda route

### DIFF
--- a/resources/js/Pages/EdaDashboard.jsx
+++ b/resources/js/Pages/EdaDashboard.jsx
@@ -614,7 +614,7 @@ const raceByPellStatusOptions = data => {
   };
 };
 
-export default function EdaDashboard({ batch_id: propBatchId }) {
+export default function EdaDashboard({ batch_id: propBatchId, clear_cache = false }) {
   const { institution } = usePage().props;
   const inst_id = institution?.inst_id;
   const [batchInfo, setBatchInfo] = useState(null);
@@ -692,6 +692,7 @@ export default function EdaDashboard({ batch_id: propBatchId }) {
         setError(null);
         const response = await axios.get(
           `/institutions/${inst_id}/batch/${batchInfo.batch_id}/eda`,
+          clear_cache ? { params: { 'clear-cache': 1 } } : undefined,
         );
 
         if (!response.data) {
@@ -727,7 +728,7 @@ export default function EdaDashboard({ batch_id: propBatchId }) {
     };
 
     fetchEdaData();
-  }, [inst_id, batchInfo]);
+  }, [inst_id, batchInfo, clear_cache]);
 
   // Create chart options from API data
   const enrollmentIntensityOption = edaData?.gpa_by_enrollment_intensity

--- a/routes/web.php
+++ b/routes/web.php
@@ -227,5 +227,6 @@ Route::middleware(['auth', 'invite.validated', 'datakinder'])->group(function ()
 Route::middleware('auth.app')->get('/eda', function (Request $request) {
     return Inertia::render('EdaDashboard', [
         'batch_id' => $request->query('batch_id'),
+        'clear_cache' => $request->query('clear-cache') === '1',
     ]);
 })->name('eda');


### PR DESCRIPTION
## Summary

Supports forcing a fresh EDA load from the app by opening the dashboard with `?clear-cache=1`. before returning data.

## Motivation

EDA results are cached to avoid repeated reads and heavy computation. Operators and developers sometimes need a forced refresh after data or logic changes without waiting for TTL expiry or restarting the service.

## Implementation

- **`routes/web.php`**: The `/eda` Inertia route passes `clear_cache` as a boolean derived from `clear-cache === '1'` in the query string (alongside existing `batch_id`).
- **`resources/js/Pages/EdaDashboard.jsx`**: Reads the `clear_cache` prop (default `false`). When true, the EDA `axios.get` includes `params: { 'clear-cache': 1 }`. The EDA fetch effect depends on `clear_cache` so the flag is applied consistently.
