### PR TITLE
fix(a11y): add labels to model run history view and download links

### DIFF
--- a/resources/js/Components/ModelRunHistory.jsx
+++ b/resources/js/Components/ModelRunHistory.jsx
@@ -50,7 +50,7 @@ const ModelRunHistory = ({ runInfos, modelName }) => {
             id="model-history-table"
           >
             <thead>
-              <tr className="border-b border-gray-300 bg-gray-50 text-xs font-medium uppercase leading-normal tracking-[0.6px] text-gray-500">
+              <tr className="border-b border-gray-300 bg-gray-50 text-xs leading-normal font-medium tracking-[0.6px] text-gray-500 uppercase">
                 <th scope="col" className="p-4 px-6">
                   DATE
                 </th>
@@ -72,7 +72,7 @@ const ModelRunHistory = ({ runInfos, modelName }) => {
             <tbody>
               {err != null ? (
                 <tr
-                  className="border-b border-gray-300 text-sm font-normal leading-5 text-gray-700"
+                  className="border-b border-gray-300 text-sm leading-5 font-normal text-gray-700"
                   key="error"
                 >
                   {err.response.data}
@@ -80,7 +80,7 @@ const ModelRunHistory = ({ runInfos, modelName }) => {
               ) : (
                 dataToDisplay.map(run => (
                   <tr
-                    className="border-b border-gray-300 text-sm font-normal leading-5 text-gray-700"
+                    className="border-b border-gray-300 text-sm leading-5 font-normal text-gray-700"
                     key={run.date}
                   >
                     <td className="p-4 px-6">{run.date}</td>

--- a/resources/js/Components/ModelRunHistory.jsx
+++ b/resources/js/Components/ModelRunHistory.jsx
@@ -95,6 +95,7 @@ const ModelRunHistory = ({ runInfos, modelName }) => {
                             run.run_id,
                             modelName,
                           ])}
+                          aria-label={`View model results for run on ${run.date}`}
                         >
                           View
                         </a>
@@ -108,6 +109,7 @@ const ModelRunHistory = ({ runInfos, modelName }) => {
                           href={run.outputLink}
                           target="_blank"
                           rel="noreferrer"
+                          aria-label={`Download model results for run on ${run.date}`}
                         >
                           Download
                         </a>


### PR DESCRIPTION
## Add accessible names to model run result links

### Summary

The “View” and “Download” links in model run history only exposed generic link text. Screen readers now get an explicit purpose for each link, including which run it refers to.

### Changes

- **View** (in-app results): `aria-label` describes opening model results for the run, using the run timestamp (`triggered_at`, shown as `run.date` in the table) in the label.
- **Download** (CSV): `aria-label` describes downloading model results for that same run.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213794914484057