### PR TITLE
fix(file-upload): restore upload progress bar lost in merge conflict

### DIFF
--- a/resources/js/Pages/FileUpload.jsx
+++ b/resources/js/Pages/FileUpload.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { Link } from '@inertiajs/react';
 import { route } from 'ziggy-js';
 import AppLayout from '@/Layouts/AppLayout';
@@ -15,6 +15,7 @@ import classNames from 'classnames';
 import BigSuccessAlert from '@/Components/BigSuccessAlert';
 import Alert from '@/Components/Alert';
 import Spinner from '@/Components/Spinner';
+import ProgressBar from '@/Components/ProgressBar';
 
 /**
  * Build a human-readable message from an axios error (Laravel `error`, FastAPI `detail`, etc.).
@@ -61,6 +62,12 @@ export default function FileUpload() {
   const [batchName, setBatchName] = useState('');
   const [modelsList, setModelsList] = useState([]);
   const [predictionResults, setPredictionResults] = useState(null);
+  /** Sum of loaded bytes per server-side file key during parallel PUTs to GCS. */
+  const uploadLoadedByKeyRef = useRef({});
+  const [uploadAggregatePct, setUploadAggregatePct] = useState(0);
+  /** How many PUTs have finished (success or fail); used to switch UI to “validating”. */
+  const [uploadPutsFinished, setUploadPutsFinished] = useState(0);
+  const [uploadBatchFileCount, setUploadBatchFileCount] = useState(0);
 
   useEffect(() => {
     axios
@@ -82,9 +89,23 @@ export default function FileUpload() {
   ];
 
   const renderProcessing = () => {
+    const allPutsDone =
+      uploadBatchFileCount > 0 && uploadPutsFinished >= uploadBatchFileCount;
     return (
-      <div className="flex w-full justify-center">
-        <Spinner mainMsg="Validation in progress"></Spinner>
+      <div className="flex w-full flex-col items-center justify-center gap-10 px-4">
+        <ProgressBar
+          className="w-full max-w-2xl"
+          progressMsg={
+            allPutsDone
+              ? 'Validating your files on the server…'
+              : 'Uploading your files…'
+          }
+          percent={allPutsDone ? null : uploadAggregatePct}
+          indeterminate={allPutsDone}
+        />
+        {allPutsDone ? (
+          <Spinner mainMsg="Validation in progress" />
+        ) : null}
       </div>
     );
   };
@@ -494,15 +515,32 @@ export default function FileUpload() {
     //setValidationResults({});
     let localValidationResults = {};
 
-    const config = {
-      headers: {
-        'Content-Type': 'text/csv',
-      },
-      timeout: 0,
+    let seq = Date.now();
+    const fileMetas = files.map(file => ({
+      file,
+      filenameConstructed: `${seq++}_${file.name}`,
+    }));
+    const totalBytes = fileMetas.reduce((s, { file: f }) => s + f.size, 0);
+    uploadLoadedByKeyRef.current = Object.fromEntries(
+      fileMetas.map(({ filenameConstructed }) => [filenameConstructed, 0]),
+    );
+    setUploadAggregatePct(0);
+    setUploadPutsFinished(0);
+    setUploadBatchFileCount(fileMetas.length);
+
+    const recomputeAggregatePct = () => {
+      const sum = fileMetas.reduce(
+        (acc, { filenameConstructed }) =>
+          acc + (uploadLoadedByKeyRef.current[filenameConstructed] || 0),
+        0,
+      );
+      setUploadAggregatePct(
+        totalBytes ? Math.min(100, Math.round((100 * sum) / totalBytes)) : 0,
+      );
     };
+
     Promise.allSettled(
-      files.map(file => {
-        var filenameConstructed = Date.now() + '_' + file.name;
+      fileMetas.map(({ file, filenameConstructed }) => {
         return axios
           .post('/file-upload-api/' + filenameConstructed)
           .then(res => {
@@ -511,12 +549,30 @@ export default function FileUpload() {
 
             if (res.data == 'local-url-fake-signed') {
               // This is the local test case, simply validate as true as we're mocking out this data.
+              uploadLoadedByKeyRef.current[filenameConstructed] = file.size;
+              recomputeAggregatePct();
               localValidationResults[filenameConstructed] = 'ok';
+              setUploadPutsFinished(c => c + 1);
               return;
             }
-            return axios
-              .put(res.data, file, config)
+            const putConfig = {
+              headers: {
+                'Content-Type': 'text/csv',
+              },
+              timeout: 0,
+              onUploadProgress: ev => {
+                uploadLoadedByKeyRef.current[filenameConstructed] = ev.loaded;
+                recomputeAggregatePct();
+              },
+            };
+            const putPromise = axios.put(res.data, file, putConfig);
+            putPromise.finally(() => {
+              setUploadPutsFinished(c => c + 1);
+            });
+            return putPromise
               .then(() => {
+                uploadLoadedByKeyRef.current[filenameConstructed] = file.size;
+                recomputeAggregatePct();
                 return axios
                   .post(
                     '/file-validate-api/' + filenameConstructed,
@@ -540,11 +596,15 @@ export default function FileUpload() {
           .catch(e => {
             localValidationResults[filenameConstructed] =
               '[Upload URL retrieval] ' + formatAxiosErrorMessage(e);
+            setUploadPutsFinished(c => c + 1);
           });
       }),
     ).then(() => {
       setValidationResults(localValidationResults);
       setProcessing(false);
+      setUploadBatchFileCount(0);
+      setUploadAggregatePct(0);
+      setUploadPutsFinished(0);
       return;
     });
   };


### PR DESCRIPTION
## Description

- Restores the file upload progress UI that was dropped when `feature/upload_progress` was merged into `develop` ([PR #274](https://github.com/datakind/edvise-ui/pull/274) only landed `ProgressBar.jsx` changes after a conflict in `FileUpload.jsx`).
- Shows aggregate upload progress across parallel GCS PUTs, then switches to an indeterminate bar and spinner while server-side validation runs.

## Deployment Readiness\*

### Testing

Describe or check:

- [ ] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional