### PR TITLE
feat: allow DataKinder to delete any model run

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -570,6 +570,10 @@ class ApiController extends Controller
     {
         \Log::info('deleteModelRun called with model_name: '.$model_name.', run_id: '.$run_id);
 
+        if ($request->user()->access_type != 'DATAKINDER') {
+            return response()->json(['error' => 'Only datakinders can perform this action'], 401);
+        }
+
         if (ApiController::isLocalRequest()) {
             return response()->json([
                 'message' => 'Run deleted successfully',

--- a/resources/js/Pages/ModelRunHistory.jsx
+++ b/resources/js/Pages/ModelRunHistory.jsx
@@ -260,7 +260,7 @@ export default function ModelRunHistory({ modelname }) {
                               )}
                             </td>
                             <td>
-                              {run.completed && (
+                              {userIsDatakinder && (
                                 <button
                                   type="button"
                                   className="cursor-pointer border-0 bg-transparent p-0"


### PR DESCRIPTION
## Description

Align with the behavior spec by allowing the deletion of any model run, not just completed runs

## Asana Task
[EDVISEBUILD-5001 - Add delete option to "model run history" page for DataKinders](https://app.asana.com/1/6325821815997/project/1208486153653829/task/1213031796227679?focus=true)

## Deployment Readiness\*

### Testing

Describe or check:

- [ ] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional